### PR TITLE
fix: 修复关闭多租户时，缺少 tenantProperties Bean 导致的启动失败

### DIFF
--- a/yudao-framework/yudao-spring-boot-starter-biz-tenant/src/main/java/cn/iocoder/yudao/framework/tenant/config/TenantPropertesAutoConfiguration.java
+++ b/yudao-framework/yudao-spring-boot-starter-biz-tenant/src/main/java/cn/iocoder/yudao/framework/tenant/config/TenantPropertesAutoConfiguration.java
@@ -1,0 +1,12 @@
+package cn.iocoder.yudao.framework.tenant.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import javax.annotation.Resource;
+
+@Configuration
+@EnableConfigurationProperties(TenantProperties.class)
+public class YudaoTenantAutoConfigurationOnDisable {
+
+}

--- a/yudao-framework/yudao-spring-boot-starter-biz-tenant/src/main/java/cn/iocoder/yudao/framework/tenant/config/TenantPropertiesAutoConfiguration.java
+++ b/yudao-framework/yudao-spring-boot-starter-biz-tenant/src/main/java/cn/iocoder/yudao/framework/tenant/config/TenantPropertiesAutoConfiguration.java
@@ -7,6 +7,6 @@ import javax.annotation.Resource;
 
 @Configuration
 @EnableConfigurationProperties(TenantProperties.class)
-public class YudaoTenantAutoConfigurationOnDisable {
+public class TenantPropertiesAutoConfiguration {
 
 }

--- a/yudao-framework/yudao-spring-boot-starter-biz-tenant/src/main/java/cn/iocoder/yudao/framework/tenant/config/YudaoTenantAutoConfiguration.java
+++ b/yudao-framework/yudao-spring-boot-starter-biz-tenant/src/main/java/cn/iocoder/yudao/framework/tenant/config/YudaoTenantAutoConfiguration.java
@@ -26,7 +26,6 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @ConditionalOnProperty(prefix = "yudao.tenant", value = "enable", matchIfMissing = true) // 允许使用 yudao.tenant.enable=false 禁用多租户
-@EnableConfigurationProperties(TenantProperties.class)
 public class YudaoTenantAutoConfiguration {
 
     // ========== AOP ==========

--- a/yudao-framework/yudao-spring-boot-starter-biz-tenant/src/main/resources/META-INF/spring.factories
+++ b/yudao-framework/yudao-spring-boot-starter-biz-tenant/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,3 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  cn.iocoder.yudao.framework.tenant.config.YudaoTenantAutoConfiguration
+  cn.iocoder.yudao.framework.tenant.config.YudaoTenantAutoConfiguration,\
+  cn.iocoder.yudao.framework.tenant.config.TenantPropertesAutoConfiguration

--- a/yudao-framework/yudao-spring-boot-starter-biz-tenant/src/main/resources/META-INF/spring.factories
+++ b/yudao-framework/yudao-spring-boot-starter-biz-tenant/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,3 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
   cn.iocoder.yudao.framework.tenant.config.YudaoTenantAutoConfiguration,\
-  cn.iocoder.yudao.framework.tenant.config.TenantPropertesAutoConfiguration
+  cn.iocoder.yudao.framework.tenant.config.TenantPropertiesAutoConfiguration


### PR DESCRIPTION
#92 
当在后端设置中关闭多租户，yudao: tenant: enable 设为 false 后，`YudaoTenantAutoConfiguration` 会因为条件不符合而跳过创建，其上的 `@EnableConfigurationProperties(TenantProperties.class)` 会被忽略，导致依赖于 `TenantProperties.class` 的bean创建失败。导致启动失败。
解决方案：
将`TenantProperties.class` 单独放在一个 `TenantPropertiesAutoConfiguration`  内创建，确保存在该 bean。