### PR TITLE
fix: 当仅存在个人权限时，确保自身能查到自己的部门名称。能查到自身的用户信息

### DIFF
--- a/yudao-module-system/yudao-module-system-impl/src/main/java/cn/iocoder/yudao/module/system/controller/admin/user/UserProfileController.java
+++ b/yudao-module-system/yudao-module-system-impl/src/main/java/cn/iocoder/yudao/module/system/controller/admin/user/UserProfileController.java
@@ -67,7 +67,8 @@ public class UserProfileController {
         resp.setRoles(UserConvert.INSTANCE.convertList(userRoles));
         // 获得部门信息
         if (user.getDeptId() != null) {
-            DeptDO dept = deptService.getDept(user.getDeptId());
+            // 使用不被数据权限拦截的部门查询方式，确保查到自己的部门名称
+            DeptDO dept = deptService.getSelfDept(user.getDeptId());
             resp.setDept(UserConvert.INSTANCE.convert02(dept));
         }
         // 获得岗位信息

--- a/yudao-module-system/yudao-module-system-impl/src/main/java/cn/iocoder/yudao/module/system/framework/datapermission/config/DataPermissionConfiguration.java
+++ b/yudao-module-system/yudao-module-system-impl/src/main/java/cn/iocoder/yudao/module/system/framework/datapermission/config/DataPermissionConfiguration.java
@@ -18,6 +18,7 @@ public class DataPermissionConfiguration {
     public DeptDataPermissionRuleCustomizer sysDeptDataPermissionRuleCustomizer() {
         return rule -> {
             rule.addDeptColumn(AdminUserDO.class);
+            rule.addUserColumn(AdminUserDO.class,"id");
             rule.addDeptColumn(DeptDO.class, "id");
         };
     }

--- a/yudao-module-system/yudao-module-system-impl/src/main/java/cn/iocoder/yudao/module/system/service/dept/DeptService.java
+++ b/yudao-module-system/yudao-module-system-impl/src/main/java/cn/iocoder/yudao/module/system/service/dept/DeptService.java
@@ -109,4 +109,11 @@ public interface DeptService {
         List<DeptDO> list = getSimpleDepts(ids);
         return CollectionUtils.convertMap(list, DeptDO::getId);
     }
+    
+    /**
+     * 获得自身的部门信息, 仅对登录用户有效，仅供内部使用
+     * 不会受到数据权限拦截
+     * @return 部门信息
+     */
+    DeptDO getSelfDept(Long id);
 }

--- a/yudao-module-system/yudao-module-system-impl/src/main/java/cn/iocoder/yudao/module/system/service/dept/DeptServiceImpl.java
+++ b/yudao-module-system/yudao-module-system-impl/src/main/java/cn/iocoder/yudao/module/system/service/dept/DeptServiceImpl.java
@@ -4,6 +4,7 @@ import cn.hutool.core.collection.CollUtil;
 import cn.iocoder.yudao.framework.common.enums.CommonStatusEnum;
 import cn.iocoder.yudao.framework.common.exception.util.ServiceExceptionUtil;
 import cn.iocoder.yudao.framework.common.util.collection.CollectionUtils;
+import cn.iocoder.yudao.framework.datapermission.core.annotation.DataPermission;
 import cn.iocoder.yudao.framework.tenant.core.aop.TenantIgnore;
 import cn.iocoder.yudao.module.system.controller.admin.dept.vo.dept.DeptCreateReqVO;
 import cn.iocoder.yudao.module.system.controller.admin.dept.vo.dept.DeptListReqVO;
@@ -304,4 +305,10 @@ public class DeptServiceImpl implements DeptService {
         return deptMapper.selectBatchIds(ids);
     }
 
+    // 关闭数据权限校验，此接口仅用于查询用户自身部门信息，不要对外开放
+    @Override
+    @DataPermission(enable = false)
+    public DeptDO getSelfDept(Long id) {
+        return deptMapper.selectById(id);
+    }
 }


### PR DESCRIPTION
1. 当数据权限仅为个人权限时，查询 userProfile 会拉不到自身的部门信息。因为部门表只设置了 dept_id 列。
这里一个解决方案是：提供一个无需数据权限的内部接口用于查询自身权限，该接口仅在 userProfile 内会被调用

2. 当数据权限仅为个人权限时，会查不到自身的 user 表信息，这里 addUserColumn 把 user 列添加进去，保证能查到自身


3. 待讨论： 本部门、本部门即子部门 权限是否应当包含查看自身的权限。如果需要包含，则需要setSelf（true）. 
一种情况是，某个表拥有 user 列但没有部门列，用户如果希望能够顺利拿到该权限必须具有查看自身的权限，因而只能选择最低的个人权限。但是这会影响到他对其他表的访问权限