### PR TITLE
sql/mysql/ruoyi-vue-pro.sql执行失败，存在多余sql代码，已去除

### DIFF
--- a/sql/mysql/ruoyi-vue-pro.sql
+++ b/sql/mysql/ruoyi-vue-pro.sql
@@ -2658,7 +2658,3 @@ COMMIT;
 
 SET FOREIGN_KEY_CHECKS = 1;
 
-
--- 积木报表菜单
-INSERT INTO `system_menu` VALUES (1281, '可视化报表', '', 1, 12, 0, '/visualization', 'chart', NULL, 0, b'1', b'1', '1', '2022-07-10 20:22:15', '1', '2022-07-10 20:33:30', b'0');
-INSERT INTO `system_menu` VALUES (1282, '积木报表', '', 2, 1, 1281, 'jm-report', '#', 'visualization/jm/index', 0, b'1', b'1', '1', '2022-07-10 20:26:36', '1', '2022-07-10 20:33:26', b'0');


### PR DESCRIPTION
sql文件中1713行和1714已经执行过的内容，在2663行和2664行被重复执行