### PR TITLE
chore: add docker compose to start dependencies easily

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+version: '3.3'
+services:
+  adminer:
+    image: adminer:4.8.1
+    restart: always
+    ports:
+      - 7777:8080
+  dbmysql:
+    image: mysql:5.7
+    restart: always
+    environment:
+      MYSQL_DATABASE: 'ruoyi-vue-pro'
+      MYSQL_ROOT_PASSWORD: '123456'
+    ports:
+      # <Port exposed> : < MySQL Port running inside container>
+      - '3306:3306'
+    command: --init-file /data/application/init.sql --default-authentication-plugin=mysql_native_password
+    expose:
+      # Opens port 3306 on the container
+      - '3306'
+      # Where our data will be persisted
+    volumes:
+      - my-db:/var/lib/mysql
+      - ./init.sql:/data/application/init.sql
+  redis:
+    image: redis
+    command: redis-server
+    restart: always
+    ports:
+      - '6379:6379'
+# Names our volume
+volumes:
+  my-db:

--- a/init.sql
+++ b/init.sql
@@ -1,0 +1,3 @@
+CREATE DATABASE IF NOT EXISTS `ruoyi-vue-pro`;
+
+USE `ruoyi-vue-pro`;


### PR DESCRIPTION
查看该项目的启动文档，发现主要依赖 MySQL 和 Redis，因为增加一个 docker-compose.yml 文件，将依赖写进这个文件里，增加使用 docker 启动项目依赖的方式，会非常方便。

对于 MySQL 和 Redis，除了手动安装以外，还可以使用如下命令，一键启动依赖项：

```
docker compose up -d
```

然后再启动项目 [YudaoServerApplication (opens new window)](https://github.com/YunaiV/ruoyi-vue-pro/blob/master/yudao-server/src/main/java/cn/iocoder/yudao/server/YudaoServerApplication.java)

类即可。

需要配置的密码等等，全写在 docker-compose.yml 文件里了，不再需要额外配置。