### PR TITLE
修复某些情况下ContextHolder的NPE异常

### DIFF
--- a/yudao-framework/yudao-spring-boot-starter-biz-data-permission/src/main/java/cn/iocoder/yudao/framework/datapermission/core/db/DataPermissionDatabaseInterceptor.java
+++ b/yudao-framework/yudao-spring-boot-starter-biz-data-permission/src/main/java/cn/iocoder/yudao/framework/datapermission/core/db/DataPermissionDatabaseInterceptor.java
@@ -539,11 +539,11 @@ public class DataPermissionDatabaseInterceptor extends JsqlParserSupport impleme
         /**
          * 该 {@link MappedStatement} 对应的规则
          */
-        private static final ThreadLocal<List<DataPermissionRule>> RULES = new TransmittableThreadLocal<>();
+        private static final ThreadLocal<List<DataPermissionRule>> RULES = ThreadLocal.withInitial(Collections::emptyList);
         /**
          * SQL 是否进行重写
          */
-        private static final ThreadLocal<Boolean> REWRITE = new TransmittableThreadLocal<>();
+        private static final ThreadLocal<Boolean> REWRITE = ThreadLocal.withInitial(() -> Boolean.FALSE);
 
         public static void init(List<DataPermissionRule> rules) {
             RULES.set(rules);


### PR DESCRIPTION
实现DataPermissionRule类，重写getExpression返回了一个InExpression实现类。报了NPE异常。

来自ChatGPT的回答

>   这个异常的根本原因是 java.lang.NullPointerException: Cannot invoke "java.lang.Boolean.booleanValue()" because the return value of "java.lang.ThreadLocal.get()" is null，在代码中，这个异常是由于 REWRITE.get() 返回了 null，从而导致调用 booleanValue() 时抛出了 NullPointerException。因此，需要检查代码中的 ThreadLocal 是否正确设置了初始值。 
  在这段代码中，REWRITE 变量是一个 ThreadLocal<Boolean> 对象，它的默认值为 null。在调用 getRewrite() 方法时，如果没有先调用 setRewrite(boolean) 方法为其设置值，那么它会返回 null。因此，为了避免这个异常，可以在调用 getRewrite() 方法之前，先调用 setRewrite(boolean) 方法为其设置一个默认值。或者，也可以在 REWRITE 变量声明时，直接设置一个默认值，如下所示：
  private static final ThreadLocal<Boolean> REWRITE = ThreadLocal.withInitial(() -> Boolean.FALSE);
  这样，如果没有显式调用 setRewrite(boolean) 方法为其设置值，REWRITE.get() 将会返回默认值 false，避免了空指针异常的出现。

And

> 由于 ContextHolder 类中的 RULES 和 REWRITE 变量都是 ThreadLocal，它们的值是与当前线程绑定的。在某个线程中调用了 ContextHolder.init(rules) 后，该线程中的 RULES 和 REWRITE 变量都会被设置为相应的值。而在其他线程中，它们的值仍然是 null（因为没有调用 init 方法），因此在其他线程中使用这些变量时，可能会出现 NullPointerException。
所以，如果在调用 beforeQuery 方法之前没有先调用 ContextHolder.init 方法，就会导致在 beforeQuery 方法中访问 RULES 和 REWRITE 变量时出现 NullPointerException。因此，在使用 ContextHolder 类时，需要注意线程安全问题，确保在每个线程中都正确地调用了 init 方法。

报错截取如下：
~~~
org.mybatis.spring.MyBatisSystemException: nested exception is org.apache.ibatis.exceptions.PersistenceException: 
### Error querying database.  Cause: java.lang.NullPointerException: Cannot invoke "java.lang.Boolean.booleanValue()" because the return value of "java.lang.ThreadLocal.get()" is null
### Cause: java.lang.NullPointerException: Cannot invoke "java.lang.Boolean.booleanValue()" because the return value of "java.lang.ThreadLocal.get()" is null
	at org.mybatis.spring.MyBatisExceptionTranslator.translateExceptionIfPossible(MyBatisExceptionTranslator.java:96)
	at org.mybatis.spring.SqlSessionTemplate$SqlSessionInterceptor.invoke(SqlSessionTemplate.java:441)
	at jdk.proxy2/jdk.proxy2.$Proxy128.selectOne(Unknown Source)
	at org.mybatis.spring.SqlSessionTemplate.selectOne(SqlSessionTemplate.java:160)
	at com.baomidou.mybatisplus.core.override.MybatisMapperMethod.execute(MybatisMapperMethod.java:89)
	at com.baomidou.mybatisplus.core.override.MybatisMapperProxy$PlainMethodInvoker.invoke(MybatisMapperProxy.java:148)
	at com.baomidou.mybatisplus.core.override.MybatisMapperProxy.invoke(MybatisMapperProxy.java:89)
	at jdk.proxy2/jdk.proxy2.$Proxy301.selectCount(Unknown Source)
	at cn.iocoder.yudao.module.creditcard.service.customer.CustomerServiceImpl.lambda$getCustomerPage$0(CustomerServiceImpl.java:86)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at cn.iocoder.yudao.module.creditcard.service.customer.CustomerServiceImpl.getCustomerPage(CustomerServiceImpl.java:85)
	at cn.iocoder.yudao.module.creditcard.service.customer.CustomerServiceImpl$$FastClassBySpringCGLIB$$6f423e4d.invoke(<generated>)
	at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218)
...
Caused by: org.apache.ibatis.exceptions.PersistenceException: 
### Error querying database.  Cause: java.lang.NullPointerException: Cannot invoke "java.lang.Boolean.booleanValue()" because the return value of "java.lang.ThreadLocal.get()" is null
### Cause: java.lang.NullPointerException: Cannot invoke "java.lang.Boolean.booleanValue()" because the return value of "java.lang.ThreadLocal.get()" is null
	at org.apache.ibatis.exceptions.ExceptionFactory.wrapException(ExceptionFactory.java:30)
	at org.apache.ibatis.session.defaults.DefaultSqlSession.selectList(DefaultSqlSession.java:153)
	at org.apache.ibatis.session.defaults.DefaultSqlSession.selectList(DefaultSqlSession.java:145)
	at org.apache.ibatis.session.defaults.DefaultSqlSession.selectList(DefaultSqlSession.java:140)
	at org.apache.ibatis.session.defaults.DefaultSqlSession.selectOne(DefaultSqlSession.java:76)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.mybatis.spring.SqlSessionTemplate$SqlSessionInterceptor.invoke(SqlSessionTemplate.java:427)
	... 174 common frames omitted
Caused by: java.lang.NullPointerException: Cannot invoke "java.lang.Boolean.booleanValue()" because the return value of "java.lang.ThreadLocal.get()" is null
	at cn.iocoder.yudao.framework.datapermission.core.db.DataPermissionDatabaseInterceptor$ContextHolder.getRewrite(DataPermissionDatabaseInterceptor.java:559)
	at cn.iocoder.yudao.framework.datapermission.core.db.DataPermissionDatabaseInterceptor.addMappedStatementCache(DataPermissionDatabaseInterceptor.java:525)
	at cn.iocoder.yudao.framework.datapermission.core.db.DataPermissionDatabaseInterceptor.beforeQuery(DataPermissionDatabaseInterceptor.java:70)
	at com.baomidou.mybatisplus.extension.plugins.MybatisPlusInterceptor.intercept(MybatisPlusInterceptor.java:78)
	at org.apache.ibatis.plugin.Plugin.invoke(Plugin.java:62)
	at jdk.proxy2/jdk.proxy2.$Proxy150.query(Unknown Source)
	at jdk.internal.reflect.GeneratedMethodAccessor95.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.apache.ibatis.plugin.Invocation.proceed(Invocation.java:49)
	at com.github.yulichang.interceptor.MPJInterceptor.intercept(MPJInterceptor.java:78)
	at org.apache.ibatis.plugin.Plugin.invoke(Plugin.java:62)
	at jdk.proxy2/jdk.proxy2.$Proxy150.query(Unknown Source)
	at org.apache.ibatis.session.defaults.DefaultSqlSession.selectList(DefaultSqlSession.java:151)
	... 182 common frames omitted
~~~