### PR TITLE
修复后端项目首次运行报 BaseDbUnitTest 类不存在的问题

### DIFF
--- a/yudao-dependencies/pom.xml
+++ b/yudao-dependencies/pom.xml
@@ -329,7 +329,7 @@
                 <groupId>cn.iocoder.boot</groupId>
                 <artifactId>yudao-spring-boot-starter-test</artifactId>
                 <version>${revision}</version>
-                <scope>test</scope>
+                <scope>runtime</scope>
             </dependency>
 
             <dependency>

--- a/yudao-framework/yudao-spring-boot-starter-biz-sms/pom.xml
+++ b/yudao-framework/yudao-spring-boot-starter-biz-sms/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>cn.iocoder.boot</groupId>
             <artifactId>yudao-spring-boot-starter-test</artifactId>
-            <scope>test</scope>
+            <scope>runtime</scope>
         </dependency>
 
         <!-- 工具类相关 -->


### PR DESCRIPTION
原先的pom配置不会去build模块yundao-test导致没有子项目测试类运行时没有yundao-test模块的target依赖包可用