### PR TITLE
fix: yudao-ui-admin前端-Cron表达式-周选择第4项，#号两边的值颠倒了

### DIFF
--- a/yudao-ui-admin/src/components/Crontab/week.vue
+++ b/yudao-ui-admin/src/components/Crontab/week.vue
@@ -185,7 +185,7 @@ export default {
 		averageTotal: function () {
 			this.average01 = this.checkNum(this.average01, 1, 4)
 			this.average02 = this.checkNum(this.average02, 1, 7)
-			return this.average02 + '#' + this.average01;
+			return this.average01 + '#' + this.average02;
 		},
 		// 最近的工作日（格式）
 		weekdayCheck: function () {


### PR DESCRIPTION
修复前端项目Cron表达式的一个问题，请求合并。希望可以共同维护