### PR TITLE
fix: 在调用 selectList() 的时候 如果 Collection 参数为空会报错 sql 异常

### DIFF
--- a/yudao-framework/yudao-spring-boot-starter-mybatis/src/main/java/cn/iocoder/yudao/framework/mybatis/core/mapper/BaseMapperX.java
+++ b/yudao-framework/yudao-spring-boot-starter-mybatis/src/main/java/cn/iocoder/yudao/framework/mybatis/core/mapper/BaseMapperX.java
@@ -1,5 +1,6 @@
 package cn.iocoder.yudao.framework.mybatis.core.mapper;
 
+import cn.hutool.core.collection.CollUtil;
 import cn.iocoder.yudao.framework.common.pojo.PageParam;
 import cn.iocoder.yudao.framework.common.pojo.PageResult;
 import cn.iocoder.yudao.framework.mybatis.core.util.MyBatisUtils;
@@ -69,10 +70,16 @@ public interface BaseMapperX<T> extends BaseMapper<T> {
     }
 
     default List<T> selectList(String field, Collection<?> values) {
+        if (CollUtil.isEmpty(values)) {
+            return CollUtil.newArrayList();
+        }
         return selectList(new QueryWrapper<T>().in(field, values));
     }
 
     default List<T> selectList(SFunction<T, ?> field, Collection<?> values) {
+        if (CollUtil.isEmpty(values)) {
+            return CollUtil.newArrayList();
+        }
         return selectList(new LambdaQueryWrapper<T>().in(field, values));
     }
 


### PR DESCRIPTION
<img width="1281" alt="image" src="https://github.com/YunaiV/ruoyi-vue-pro/assets/62475939/df3fe2ae-8e2c-422c-96ad-7cf403759399">
在调用 封装的 Mapper 层时候, 如果传入的数组为空, 拼接会报错, 直接返回空数组