### PR TITLE
修复错误拼写的注释

### DIFF
--- a/yudao-framework/yudao-spring-boot-starter-test/src/main/java/cn/iocoder/yudao/framework/test/core/ut/BaseDbAndRedisUnitTest.java
+++ b/yudao-framework/yudao-spring-boot-starter-test/src/main/java/cn/iocoder/yudao/framework/test/core/ut/BaseDbAndRedisUnitTest.java
@@ -43,7 +43,7 @@ public class BaseDbAndRedisUnitTest {
             RedisTestConfiguration.class, // Redis 测试配置类，用于启动 RedisServer
             YudaoRedisAutoConfiguration.class, // 自己的 Redis 配置类
             RedisAutoConfiguration.class, // Spring Redis 自动配置类
-            RedissonAutoConfiguration.class, // Redisson 自动高配置类
+            RedissonAutoConfiguration.class, // Redisson 自动配置类
     })
     public static class Application {
     }

--- a/yudao-framework/yudao-spring-boot-starter-test/src/main/java/cn/iocoder/yudao/framework/test/core/ut/BaseRedisUnitTest.java
+++ b/yudao-framework/yudao-spring-boot-starter-test/src/main/java/cn/iocoder/yudao/framework/test/core/ut/BaseRedisUnitTest.java
@@ -24,7 +24,7 @@ public class BaseRedisUnitTest {
             RedisTestConfiguration.class, // Redis 测试配置类，用于启动 RedisServer
             RedisAutoConfiguration.class, // Spring Redis 自动配置类
             YudaoRedisAutoConfiguration.class, // 自己的 Redis 配置类
-            RedissonAutoConfiguration.class, // Redisson 自动高配置类
+            RedissonAutoConfiguration.class, // Redisson 自动配置类
     })
     public static class Application {
     }

--- a/yudao-module-pay/yudao-module-pay-biz/src/test-integration/java/cn/iocoder/yudao/module/pay/test/BaseDbAndRedisIntegrationTest.java
+++ b/yudao-module-pay/yudao-module-pay-biz/src/test-integration/java/cn/iocoder/yudao/module/pay/test/BaseDbAndRedisIntegrationTest.java
@@ -30,7 +30,7 @@ public class BaseDbAndRedisIntegrationTest {
             // Redis 配置类
             RedisAutoConfiguration.class, // Spring Redis 自动配置类
             YudaoRedisAutoConfiguration.class, // 自己的 Redis 配置类
-            RedissonAutoConfiguration.class, // Redisson 自动高配置类
+            RedissonAutoConfiguration.class, // Redisson 自动配置类
     })
     public static class Application {
     }

--- a/yudao-module-pay/yudao-module-pay-biz/src/test-integration/java/cn/iocoder/yudao/module/pay/test/BaseRedisIntegrationTest.java
+++ b/yudao-module-pay/yudao-module-pay-biz/src/test-integration/java/cn/iocoder/yudao/module/pay/test/BaseRedisIntegrationTest.java
@@ -15,7 +15,7 @@ public class BaseRedisIntegrationTest {
             // Redis 配置类
             RedisAutoConfiguration.class, // Spring Redis 自动配置类
             YudaoRedisAutoConfiguration.class, // 自己的 Redis 配置类
-            RedissonAutoConfiguration.class, // Redisson 自动高配置类
+            RedissonAutoConfiguration.class, // Redisson 自动配置类
     })
     public static class Application {
     }


### PR DESCRIPTION
"Redisson 自动高配置类" 改为 "Redisson 自动配置类"