### PR TITLE
【修复】商城首页销售额查询错误

### DIFF
--- a/yudao-module-mall/yudao-module-statistics-biz/src/main/java/cn/iocoder/yudao/module/statistics/dal/mysql/pay/PayWalletStatisticsMapper.java
+++ b/yudao-module-mall/yudao-module-statistics-biz/src/main/java/cn/iocoder/yudao/module/statistics/dal/mysql/pay/PayWalletStatisticsMapper.java
@@ -33,6 +33,6 @@ public interface PayWalletStatisticsMapper extends BaseMapperX {
                                                                @Param("endTime") LocalDateTime endTime,
                                                                @Param("payStatus") Boolean payStatus);
 
-    Integer selectRechargePriceSummary(@Param("payStatus") Integer payStatus);
+    Integer selectRechargePriceSummary(@Param("payStatus") Boolean payStatus);
 
 }

--- a/yudao-module-mall/yudao-module-statistics-biz/src/main/java/cn/iocoder/yudao/module/statistics/dal/mysql/trade/TradeOrderStatisticsMapper.java
+++ b/yudao-module-mall/yudao-module-statistics-biz/src/main/java/cn/iocoder/yudao/module/statistics/dal/mysql/trade/TradeOrderStatisticsMapper.java
@@ -58,7 +58,7 @@ public interface TradeOrderStatisticsMapper extends BaseMapperX<TradeStatisticsD
 
     Long selectCountByStatusAndDeliveryType(@Param("status") Integer status, @Param("deliveryType") Integer deliveryType);
 
-    TradeOrderSummaryRespVO selectPaySummaryByPayStatusAndPayTimeBetween(@Param("payStatus") Integer payStatus,
+    TradeOrderSummaryRespVO selectPaySummaryByPayStatusAndPayTimeBetween(@Param("payStatus") Boolean payStatus,
                                                                          @Param("beginTime") LocalDateTime beginTime,
                                                                          @Param("endTime") LocalDateTime endTime);
 

--- a/yudao-module-mall/yudao-module-statistics-biz/src/main/java/cn/iocoder/yudao/module/statistics/service/pay/PayWalletStatisticsServiceImpl.java
+++ b/yudao-module-mall/yudao-module-statistics-biz/src/main/java/cn/iocoder/yudao/module/statistics/service/pay/PayWalletStatisticsServiceImpl.java
@@ -46,7 +46,7 @@ public class PayWalletStatisticsServiceImpl implements PayWalletStatisticsServic
 
     @Override
     public Integer getRechargePriceSummary() {
-        return payWalletStatisticsMapper.selectRechargePriceSummary(PayOrderStatusEnum.SUCCESS.getStatus());
+        return payWalletStatisticsMapper.selectRechargePriceSummary(Boolean.TRUE);
     }
 
 }

--- a/yudao-module-mall/yudao-module-statistics-biz/src/main/java/cn/iocoder/yudao/module/statistics/service/trade/TradeOrderStatisticsServiceImpl.java
+++ b/yudao-module-mall/yudao-module-statistics-biz/src/main/java/cn/iocoder/yudao/module/statistics/service/trade/TradeOrderStatisticsServiceImpl.java
@@ -77,7 +77,7 @@ public class TradeOrderStatisticsServiceImpl implements TradeOrderStatisticsServ
         LocalDateTime beginTime = LocalDateTimeUtil.beginOfDay(date);
         LocalDateTime endTime = LocalDateTimeUtil.endOfDay(date);
         return tradeOrderStatisticsMapper.selectPaySummaryByPayStatusAndPayTimeBetween(
-                PayOrderStatusEnum.SUCCESS.getStatus(), beginTime, endTime);
+                Boolean.TRUE, beginTime, endTime);
     }
 
     @Override


### PR DESCRIPTION
使用了错误的字段枚举做了查询条件，导致查询不到数据，payWalletStatisticsMapper中也存在同样的问题，一并修复了