### PR TITLE
fix：上传文件测试时pg数据库字段与FileContentDO类型不一致报错修复

### DIFF
--- a/yudao-module-infra/yudao-module-infra-biz/src/main/java/cn/iocoder/yudao/module/infra/dal/dataobject/file/FileContentDO.java
+++ b/yudao-module-infra/yudao-module-infra-biz/src/main/java/cn/iocoder/yudao/module/infra/dal/dataobject/file/FileContentDO.java
@@ -28,8 +28,8 @@ public class FileContentDO extends BaseDO {
     /**
      * 编号，数据库自增
      */
-    @TableId(type = IdType.INPUT)
-    private String id;
+    @TableId
+    private Long id;
     /**
      * 配置编号
      *


### PR DESCRIPTION
文件管理-文件配置页面，数据库点击测试，错误详情Caused by: org.postgresql.util.PSQLException: ERROR: column "id" is of type bigint but expression is of type character varying