### PR TITLE
【修复】获取菜单精简信息列表接口没有排除父 ID 非 0 的节点

### DIFF
--- a/yudao-module-system/yudao-module-system-biz/src/main/java/cn/iocoder/yudao/module/system/controller/admin/auth/AuthController.java
+++ b/yudao-module-system/yudao-module-system-biz/src/main/java/cn/iocoder/yudao/module/system/controller/admin/auth/AuthController.java
@@ -109,9 +109,10 @@ public class AuthController {
         // 1.3 获得菜单列表
         Set<Long> menuIds = permissionService.getRoleMenuListByRoleId(convertSet(roles, RoleDO::getId));
         List<MenuDO> menuList = menuService.getMenuList(menuIds);
-        // 过滤掉关闭的菜单及其子菜单
+        // 过滤掉关闭的菜单
         menuList = menuService.filterClosedMenus(menuList);
 
+        menuList.removeIf(menu -> !CommonStatusEnum.ENABLE.getStatus().equals(menu.getStatus())); // 移除禁用的菜单
         // 2. 拼接结果返回
         return success(AuthConvert.INSTANCE.convert(user, roles, menuList));
     }

--- a/yudao-module-system/yudao-module-system-biz/src/main/java/cn/iocoder/yudao/module/system/controller/admin/auth/AuthController.java
+++ b/yudao-module-system/yudao-module-system-biz/src/main/java/cn/iocoder/yudao/module/system/controller/admin/auth/AuthController.java
@@ -109,7 +109,6 @@ public class AuthController {
         // 1.3 获得菜单列表
         Set<Long> menuIds = permissionService.getRoleMenuListByRoleId(convertSet(roles, RoleDO::getId));
         List<MenuDO> menuList = menuService.getMenuList(menuIds);
-        menuList.removeIf(menu -> !CommonStatusEnum.ENABLE.getStatus().equals(menu.getStatus())); // 移除禁用的菜单
 
         // 2. 拼接结果返回
         return success(AuthConvert.INSTANCE.convert(user, roles, menuList));

--- a/yudao-module-system/yudao-module-system-biz/src/main/java/cn/iocoder/yudao/module/system/controller/admin/auth/AuthController.java
+++ b/yudao-module-system/yudao-module-system-biz/src/main/java/cn/iocoder/yudao/module/system/controller/admin/auth/AuthController.java
@@ -109,8 +109,7 @@ public class AuthController {
         // 1.3 获得菜单列表
         Set<Long> menuIds = permissionService.getRoleMenuListByRoleId(convertSet(roles, RoleDO::getId));
         List<MenuDO> menuList = menuService.getMenuList(menuIds);
-        // 过滤掉关闭的菜单
-        menuList = menuService.filterClosedMenus(menuList);
+        menuList = menuService.filterDisableMenus(menuList);
 
         // 2. 拼接结果返回
         return success(AuthConvert.INSTANCE.convert(user, roles, menuList));

--- a/yudao-module-system/yudao-module-system-biz/src/main/java/cn/iocoder/yudao/module/system/controller/admin/auth/AuthController.java
+++ b/yudao-module-system/yudao-module-system-biz/src/main/java/cn/iocoder/yudao/module/system/controller/admin/auth/AuthController.java
@@ -109,6 +109,8 @@ public class AuthController {
         // 1.3 获得菜单列表
         Set<Long> menuIds = permissionService.getRoleMenuListByRoleId(convertSet(roles, RoleDO::getId));
         List<MenuDO> menuList = menuService.getMenuList(menuIds);
+        // 过滤掉关闭的菜单及其子菜单
+        menuList = menuService.filterClosedMenus(menuList);
 
         // 2. 拼接结果返回
         return success(AuthConvert.INSTANCE.convert(user, roles, menuList));

--- a/yudao-module-system/yudao-module-system-biz/src/main/java/cn/iocoder/yudao/module/system/controller/admin/auth/AuthController.java
+++ b/yudao-module-system/yudao-module-system-biz/src/main/java/cn/iocoder/yudao/module/system/controller/admin/auth/AuthController.java
@@ -112,7 +112,6 @@ public class AuthController {
         // 过滤掉关闭的菜单
         menuList = menuService.filterClosedMenus(menuList);
 
-        menuList.removeIf(menu -> !CommonStatusEnum.ENABLE.getStatus().equals(menu.getStatus())); // 移除禁用的菜单
         // 2. 拼接结果返回
         return success(AuthConvert.INSTANCE.convert(user, roles, menuList));
     }

--- a/yudao-module-system/yudao-module-system-biz/src/main/java/cn/iocoder/yudao/module/system/controller/admin/permission/MenuController.java
+++ b/yudao-module-system/yudao-module-system-biz/src/main/java/cn/iocoder/yudao/module/system/controller/admin/permission/MenuController.java
@@ -71,7 +71,7 @@ public class MenuController {
             "在多租户的场景下，会只返回租户所在套餐有的菜单")
     public CommonResult<List<MenuSimpleRespVO>> getSimpleMenuList() {
         List<MenuDO> list = menuService.getMenuListByTenant(
-                new MenuListReqVO().setStatus(CommonStatusEnum.ENABLE.getStatus()));
+                new MenuListReqVO());
         list.sort(Comparator.comparing(MenuDO::getSort));
         return success(BeanUtils.toBean(list, MenuSimpleRespVO.class));
     }

--- a/yudao-module-system/yudao-module-system-biz/src/main/java/cn/iocoder/yudao/module/system/controller/admin/permission/MenuController.java
+++ b/yudao-module-system/yudao-module-system-biz/src/main/java/cn/iocoder/yudao/module/system/controller/admin/permission/MenuController.java
@@ -72,8 +72,7 @@ public class MenuController {
     public CommonResult<List<MenuSimpleRespVO>> getSimpleMenuList() {
         List<MenuDO> list = menuService.getMenuListByTenant(
                 new MenuListReqVO().setStatus(CommonStatusEnum.ENABLE.getStatus()));
-        // 过滤掉关闭的菜单及其子菜单
-        list = menuService.filterClosedMenus(list);
+        list = menuService.filterDisableMenus(list);
         list.sort(Comparator.comparing(MenuDO::getSort));
         return success(BeanUtils.toBean(list, MenuSimpleRespVO.class));
     }

--- a/yudao-module-system/yudao-module-system-biz/src/main/java/cn/iocoder/yudao/module/system/controller/admin/permission/MenuController.java
+++ b/yudao-module-system/yudao-module-system-biz/src/main/java/cn/iocoder/yudao/module/system/controller/admin/permission/MenuController.java
@@ -71,7 +71,9 @@ public class MenuController {
             "在多租户的场景下，会只返回租户所在套餐有的菜单")
     public CommonResult<List<MenuSimpleRespVO>> getSimpleMenuList() {
         List<MenuDO> list = menuService.getMenuListByTenant(
-                new MenuListReqVO());
+                new MenuListReqVO().setStatus(CommonStatusEnum.ENABLE.getStatus()));
+        // 过滤掉关闭的菜单及其子菜单
+        list = menuService.filterClosedMenus(list);
         list.sort(Comparator.comparing(MenuDO::getSort));
         return success(BeanUtils.toBean(list, MenuSimpleRespVO.class));
     }

--- a/yudao-module-system/yudao-module-system-biz/src/main/java/cn/iocoder/yudao/module/system/service/permission/MenuService.java
+++ b/yudao-module-system/yudao-module-system-biz/src/main/java/cn/iocoder/yudao/module/system/service/permission/MenuService.java
@@ -53,6 +53,14 @@ public interface MenuService {
     List<MenuDO> getMenuListByTenant(MenuListReqVO reqVO);
 
     /**
+     * 过滤掉关闭的菜单及其子菜单
+     *
+     * @param menuList
+     * @return
+     */
+    List<MenuDO> filterClosedMenus(List<MenuDO> menuList);
+
+    /**
      * 筛选菜单列表
      *
      * @param reqVO 筛选条件请求 VO

--- a/yudao-module-system/yudao-module-system-biz/src/main/java/cn/iocoder/yudao/module/system/service/permission/MenuService.java
+++ b/yudao-module-system/yudao-module-system-biz/src/main/java/cn/iocoder/yudao/module/system/service/permission/MenuService.java
@@ -55,10 +55,10 @@ public interface MenuService {
     /**
      * 过滤掉关闭的菜单及其子菜单
      *
-     * @param menuList
-     * @return
+     * @param list 菜单列表
+     * @return List<MenuDO> 过滤后的菜单列表
      */
-    List<MenuDO> filterClosedMenus(List<MenuDO> menuList);
+    List<MenuDO> filterDisableMenus(List<MenuDO> list);
 
     /**
      * 筛选菜单列表

--- a/yudao-module-system/yudao-module-system-biz/src/main/java/cn/iocoder/yudao/module/system/service/permission/MenuServiceImpl.java
+++ b/yudao-module-system/yudao-module-system-biz/src/main/java/cn/iocoder/yudao/module/system/service/permission/MenuServiceImpl.java
@@ -126,16 +126,18 @@ public class MenuServiceImpl implements MenuService {
         if(CollectionUtils.isEmpty(menuList)){
             return Collections.emptyList();
         }
+        List<MenuDO> allMenuList = getMenuList();
+
         // 根据parentId快速查找子节点
-        Map<Long, List<MenuDO>> childrenMap = menuList.stream()
+        Map<Long, List<MenuDO>> childrenMap = allMenuList.stream()
                 .collect(Collectors.groupingBy(MenuDO::getParentId));
 
         // 所有关闭的节点ID
         Set<Long> closedNodeIds = new HashSet<>();
 
         // 标记所有关闭的节点
-        for (MenuDO menu : menuList) {
-            if (Objects.equals(menu.getStatus(), CommonStatusEnum.DISABLE.getStatus())) {
+        for (MenuDO menu : allMenuList) {
+            if (!Objects.equals(menu.getStatus(), CommonStatusEnum.ENABLE.getStatus())) {
                 markClosedNodes(menu.getId(), childrenMap, closedNodeIds);
             }
         }


### PR DESCRIPTION
在查询菜单列表时, 在服务端对菜单树进行构建, 将所有父 ID 非 0 的根菜单全部排除后返回给客户端. 缺点是管理端每次加载树的时候服务端都要重新进行一次过滤.

涉及接口：
/system/menu/list-all-simple

/system/auth/get-permission-info