### PR TITLE
Add WeChat template message handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,3 +362,39 @@
 | ![](/.image/admin-uniapp/07.png) | ![](/.image/admin-uniapp/08.png) | ![](/.image/admin-uniapp/09.png) |
 
 目前已经实现登录、我的、工作台、编辑资料、头像修改、密码修改、常见问题、关于我们等基础功能。
+
+### 微信公众号的模版消息对接
+
+`yudao-module-mp` 模块现已支持微信公众号的模版消息对接功能。以下是使用说明和示例：
+
+#### 使用说明
+
+1. 确保在 `pom.xml` 文件中取消注释 `yudao-module-mp` 模块，以便将其包含在构建过程中。
+2. 在 `yudao-module-mp/yudao-module-mp-biz/src/main/java/cn/iocoder/yudao/module/mp/service/message` 目录下，定义 `MpTemplateMessageService` 接口，并在同一目录下实现该接口。
+3. 在 `yudao-module-mp/yudao-module-mp-biz/src/main/java/cn/iocoder/yudao/module/mp/service/handler/message` 目录下，添加 `TemplateMessageHandler` 类以处理传入的模版消息。
+
+#### 示例
+
+以下是一个发送模版消息的示例：
+
+```java
+@Service
+public class MpTemplateMessageServiceImpl implements MpTemplateMessageService {
+
+    @Resource
+    private MpServiceFactory mpServiceFactory;
+
+    @Override
+    public void sendTemplateMessage(WxMpTemplateMessage templateMessage) {
+        WxMpService mpService = mpServiceFactory.getRequiredMpService(templateMessage.getAppid());
+        try {
+            mpService.getTemplateMsgService().sendTemplateMsg(templateMessage);
+        } catch (WxErrorException e) {
+            log.error("[sendTemplateMessage][发送模板消息失败，templateMessage={}]", templateMessage, e);
+            throw new RuntimeException("发送模板消息失败", e);
+        }
+    }
+}
+```
+
+更多详细信息，请参考项目中的相关代码和文档。

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 <!--        <module>yudao-module-member</module>-->
 <!--        <module>yudao-module-bpm</module>-->
 <!--        <module>yudao-module-report</module>-->
-<!--        <module>yudao-module-mp</module>-->
+        <module>yudao-module-mp</module>
 <!--        <module>yudao-module-pay</module>-->
 <!--        <module>yudao-module-mall</module>-->
 <!--        <module>yudao-module-crm</module>-->

--- a/yudao-module-mp/yudao-module-mp-biz/src/main/java/cn/iocoder/yudao/module/mp/service/handler/message/TemplateMessageHandler.java
+++ b/yudao-module-mp/yudao-module-mp-biz/src/main/java/cn/iocoder/yudao/module/mp/service/handler/message/TemplateMessageHandler.java
@@ -1,0 +1,35 @@
+package cn.iocoder.yudao.module.mp.service.handler.message;
+
+import cn.iocoder.yudao.module.mp.framework.mp.core.context.MpContextHolder;
+import cn.iocoder.yudao.module.mp.service.message.MpTemplateMessageService;
+import lombok.extern.slf4j.Slf4j;
+import me.chanjar.weixin.common.session.WxSessionManager;
+import me.chanjar.weixin.mp.api.WxMpMessageHandler;
+import me.chanjar.weixin.mp.api.WxMpService;
+import me.chanjar.weixin.mp.bean.message.WxMpXmlMessage;
+import me.chanjar.weixin.mp.bean.message.WxMpXmlOutMessage;
+import org.springframework.stereotype.Component;
+
+import jakarta.annotation.Resource;
+import java.util.Map;
+
+/**
+ * 模板消息的事件处理器
+ */
+@Component
+@Slf4j
+public class TemplateMessageHandler implements WxMpMessageHandler {
+
+    @Resource
+    private MpTemplateMessageService mpTemplateMessageService;
+
+    @Override
+    public WxMpXmlOutMessage handle(WxMpXmlMessage wxMessage, Map<String, Object> context,
+                                    WxMpService wxMpService, WxSessionManager sessionManager) {
+        log.info("[handle][接收到模板消息，内容：{}]", wxMessage);
+        // 处理模板消息的逻辑
+        mpTemplateMessageService.sendTemplateMessage(MpContextHolder.getAppId(), wxMessage);
+        return null;
+    }
+
+}

--- a/yudao-module-mp/yudao-module-mp-biz/src/main/java/cn/iocoder/yudao/module/mp/service/message/MpTemplateMessageService.java
+++ b/yudao-module-mp/yudao-module-mp-biz/src/main/java/cn/iocoder/yudao/module/mp/service/message/MpTemplateMessageService.java
@@ -1,0 +1,17 @@
+package cn.iocoder.yudao.module.mp.service.message;
+
+import me.chanjar.weixin.mp.bean.template.WxMpTemplateMessage;
+
+/**
+ * 公众号模板消息 Service 接口
+ */
+public interface MpTemplateMessageService {
+
+    /**
+     * 发送模板消息
+     *
+     * @param templateMessage 模板消息
+     */
+    void sendTemplateMessage(WxMpTemplateMessage templateMessage);
+
+}

--- a/yudao-module-mp/yudao-module-mp-biz/src/main/java/cn/iocoder/yudao/module/mp/service/message/MpTemplateMessageServiceImpl.java
+++ b/yudao-module-mp/yudao-module-mp-biz/src/main/java/cn/iocoder/yudao/module/mp/service/message/MpTemplateMessageServiceImpl.java
@@ -1,0 +1,32 @@
+package cn.iocoder.yudao.module.mp.service.message;
+
+import cn.iocoder.yudao.module.mp.framework.mp.core.MpServiceFactory;
+import lombok.extern.slf4j.Slf4j;
+import me.chanjar.weixin.common.error.WxErrorException;
+import me.chanjar.weixin.mp.api.WxMpService;
+import me.chanjar.weixin.mp.bean.template.WxMpTemplateMessage;
+import org.springframework.stereotype.Service;
+import org.springframework.validation.annotation.Validated;
+
+import jakarta.annotation.Resource;
+
+@Service
+@Validated
+@Slf4j
+public class MpTemplateMessageServiceImpl implements MpTemplateMessageService {
+
+    @Resource
+    private MpServiceFactory mpServiceFactory;
+
+    @Override
+    public void sendTemplateMessage(WxMpTemplateMessage templateMessage) {
+        WxMpService mpService = mpServiceFactory.getRequiredMpService(templateMessage.getAppid());
+        try {
+            mpService.getTemplateMsgService().sendTemplateMsg(templateMessage);
+        } catch (WxErrorException e) {
+            log.error("[sendTemplateMessage][发送模板消息失败，templateMessage={}]", templateMessage, e);
+            throw new RuntimeException("发送模板消息失败", e);
+        }
+    }
+
+}


### PR DESCRIPTION
Add support for WeChat template messages in the `yudao-module-mp` module.

* **pom.xml**
  - Uncomment the `yudao-module-mp` module to include it in the build process.

* **MpTemplateMessageService.java**
  - Define the `MpTemplateMessageService` interface.
  - Add a method to send template messages.

* **MpTemplateMessageServiceImpl.java**
  - Implement the `MpTemplateMessageService` interface.
  - Add logic to send template messages using the WeChat API.

* **TemplateMessageHandler.java**
  - Define the `TemplateMessageHandler` class.
  - Implement the `WxMpMessageHandler` interface.
  - Add logic to handle incoming template messages.

* **README.md**
  - Add a section about the new template message handling feature.
  - Include usage instructions and examples.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/YunaiV/ruoyi-vue-pro?shareId=79dbd8e0-e408-4b50-9671-ec6491813d87).