### PR TITLE
fix: 修复引入ai模块导致swagger文档失效问题

### DIFF
--- a/yudao-module-ai/yudao-spring-boot-starter-ai/pom.xml
+++ b/yudao-module-ai/yudao-spring-boot-starter-ai/pom.xml
@@ -67,6 +67,12 @@
                     <artifactId>spring-cloud-function-core</artifactId>
                     <groupId>org.springframework.cloud</groupId>
                 </exclusion>
+                <!-- swagger-annotations 2.2.20会导致Schema解析方法错误 -->
+                <!-- https://github.com/spring-projects/spring-ai/pull/2024/commits/7315b8a09f1e7f3a86d480e0d81bffa45b3238ff -->
+                <exclusion>
+                    <groupId>io.swagger.core.v3</groupId>
+                    <artifactId>swagger-annotations</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
spring-ai 1.1.0 引入了swagger-annotations 2.2.20，它与swagger-annotations-jakarta共存会导致swagger文档解析时出现@Schema解析错误。
spring-ai 有相关issue和PR，解决方案是将swagger-annotations升级到2.2.25。本项目中如果不改变spring-ai版本，则需要排除依赖。
参考：https://github.com/spring-projects/spring-ai/pull/2024/commits/7315b8a09f1e7f3a86d480e0d81bffa45b3238ff