### PR TITLE
【Simple设计器】流程模型->基本信息->谁可以发起，支持指定多个部门

### DIFF
--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/controller/admin/base/dept/DeptSimpleBaseVO.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/controller/admin/base/dept/DeptSimpleBaseVO.java
@@ -1,0 +1,13 @@
+package cn.iocoder.yudao.module.bpm.controller.admin.base.dept;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Schema(description = "部门精简信息 VO")
+@Data
+public class DeptSimpleBaseVO {
+    @Schema(description = "部门编号", requiredMode = Schema.RequiredMode.REQUIRED, example = "1")
+    private Long id;
+    @Schema(description = "部门名称", requiredMode = Schema.RequiredMode.REQUIRED, example = "芋艿")
+    private String name;
+}

--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/controller/admin/definition/BpmModelController.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/controller/admin/definition/BpmModelController.java
@@ -12,6 +12,8 @@ import cn.iocoder.yudao.module.bpm.service.definition.BpmCategoryService;
 import cn.iocoder.yudao.module.bpm.service.definition.BpmFormService;
 import cn.iocoder.yudao.module.bpm.service.definition.BpmModelService;
 import cn.iocoder.yudao.module.bpm.service.definition.BpmProcessDefinitionService;
+import cn.iocoder.yudao.module.system.api.dept.DeptApi;
+import cn.iocoder.yudao.module.system.api.dept.dto.DeptRespDTO;
 import cn.iocoder.yudao.module.system.api.user.AdminUserApi;
 import cn.iocoder.yudao.module.system.api.user.dto.AdminUserRespDTO;
 import io.swagger.v3.oas.annotations.Operation;
@@ -53,6 +55,8 @@ public class BpmModelController {
 
     @Resource
     private AdminUserApi adminUserApi;
+    @Resource
+    private DeptApi deptApi;
 
     @GetMapping("/list")
     @Operation(summary = "获得模型分页")
@@ -85,8 +89,14 @@ public class BpmModelController {
             return metaInfo != null ? metaInfo.getStartUserIds().stream() : Stream.empty();
         });
         Map<Long, AdminUserRespDTO> userMap = adminUserApi.getUserMap(userIds);
+        // 获得 Dept Map
+        Set<Long> deptIds = convertSetByFlatMap(list, model -> {
+            BpmModelMetaInfoVO metaInfo = BpmModelConvert.INSTANCE.parseMetaInfo(model);
+            return metaInfo != null && metaInfo.getStartDeptIds() != null ? metaInfo.getStartDeptIds().stream() : Stream.empty();
+        });
+        Map<Long, DeptRespDTO> deptMap = deptApi.getDeptMap(deptIds);
         return success(BpmModelConvert.INSTANCE.buildModelList(list,
-                formMap, categoryMap, deploymentMap, processDefinitionMap, userMap));
+                formMap, categoryMap, deploymentMap, processDefinitionMap, userMap, deptMap));
     }
 
     @GetMapping("/get")

--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/controller/admin/definition/vo/model/BpmModelMetaInfoVO.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/controller/admin/definition/vo/model/BpmModelMetaInfoVO.java
@@ -59,6 +59,9 @@ public class BpmModelMetaInfoVO {
     @Schema(description = "可发起用户编号数组", example = "[1,2,3]")
     private List<Long> startUserIds;
 
+    @Schema(description = "可发起部门编号数组")
+    private List<Long> startDeptIds;
+
     @Schema(description = "可管理用户编号数组", requiredMode = Schema.RequiredMode.REQUIRED, example = "[2,4,6]")
     @NotEmpty(message = "可管理用户编号数组不能为空")
     private List<Long> managerUserIds;

--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/controller/admin/definition/vo/model/BpmModelRespVO.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/controller/admin/definition/vo/model/BpmModelRespVO.java
@@ -1,5 +1,6 @@
 package cn.iocoder.yudao.module.bpm.controller.admin.definition.vo.model;
 
+import cn.iocoder.yudao.module.bpm.controller.admin.base.dept.DeptSimpleBaseVO;
 import cn.iocoder.yudao.module.bpm.controller.admin.base.user.UserSimpleBaseVO;
 import cn.iocoder.yudao.module.bpm.controller.admin.definition.vo.model.simple.BpmSimpleModelNodeVO;
 import cn.iocoder.yudao.module.bpm.controller.admin.definition.vo.process.BpmProcessDefinitionRespVO;
@@ -38,6 +39,9 @@ public class BpmModelRespVO extends BpmModelMetaInfoVO {
 
     @Schema(description = "可发起的用户数组")
     private List<UserSimpleBaseVO> startUsers;
+
+    @Schema(description = "可发起的部门数组")
+    private List<DeptSimpleBaseVO> startDepts;
 
     @Schema(description = "BPMN XML")
     private String bpmnXml;

--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/convert/definition/BpmModelConvert.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/convert/definition/BpmModelConvert.java
@@ -4,6 +4,7 @@ import cn.hutool.core.util.ArrayUtil;
 import cn.iocoder.yudao.framework.common.util.date.DateUtils;
 import cn.iocoder.yudao.framework.common.util.json.JsonUtils;
 import cn.iocoder.yudao.framework.common.util.object.BeanUtils;
+import cn.iocoder.yudao.module.bpm.controller.admin.base.dept.DeptSimpleBaseVO;
 import cn.iocoder.yudao.module.bpm.controller.admin.base.user.UserSimpleBaseVO;
 import cn.iocoder.yudao.module.bpm.controller.admin.definition.vo.model.BpmModelMetaInfoVO;
 import cn.iocoder.yudao.module.bpm.controller.admin.definition.vo.model.BpmModelRespVO;
@@ -13,6 +14,7 @@ import cn.iocoder.yudao.module.bpm.controller.admin.definition.vo.process.BpmPro
 import cn.iocoder.yudao.module.bpm.dal.dataobject.definition.BpmCategoryDO;
 import cn.iocoder.yudao.module.bpm.dal.dataobject.definition.BpmFormDO;
 import cn.iocoder.yudao.module.bpm.framework.flowable.core.util.BpmnModelUtils;
+import cn.iocoder.yudao.module.system.api.dept.dto.DeptRespDTO;
 import cn.iocoder.yudao.module.system.api.user.dto.AdminUserRespDTO;
 import org.flowable.common.engine.impl.db.SuspensionState;
 import org.flowable.engine.repository.Deployment;
@@ -43,7 +45,8 @@ public interface BpmModelConvert {
                                                 Map<String, BpmCategoryDO> categoryMap,
                                                 Map<String, Deployment> deploymentMap,
                                                 Map<String, ProcessDefinition> processDefinitionMap,
-                                                Map<Long, AdminUserRespDTO> userMap) {
+                                                Map<Long, AdminUserRespDTO> userMap,
+                                                Map<Long, DeptRespDTO> deptMap) {
         List<BpmModelRespVO> result = convertList(list, model -> {
             BpmModelMetaInfoVO metaInfo = parseMetaInfo(model);
             BpmFormDO form = metaInfo != null ? formMap.get(metaInfo.getFormId()) : null;
@@ -52,7 +55,8 @@ public interface BpmModelConvert {
             ProcessDefinition processDefinition = model.getDeploymentId() != null ?
                     processDefinitionMap.get(model.getDeploymentId()) : null;
             List<AdminUserRespDTO> startUsers = metaInfo != null ? convertList(metaInfo.getStartUserIds(), userMap::get) : null;
-            return buildModel0(model, metaInfo, form, category, deployment, processDefinition, startUsers);
+            List<DeptRespDTO> startDepts = metaInfo != null ? convertList(metaInfo.getStartDeptIds(), deptMap::get) : null;
+            return buildModel0(model, metaInfo, form, category, deployment, processDefinition, startUsers, startDepts);
         });
         // 排序
         result.sort(Comparator.comparing(BpmModelMetaInfoVO::getSort));
@@ -61,7 +65,7 @@ public interface BpmModelConvert {
 
     default BpmModelRespVO buildModel(Model model, byte[] bpmnBytes, BpmSimpleModelNodeVO simpleModel) {
         BpmModelMetaInfoVO metaInfo = parseMetaInfo(model);
-        BpmModelRespVO modelVO = buildModel0(model, metaInfo, null, null, null, null, null);
+        BpmModelRespVO modelVO = buildModel0(model, metaInfo, null, null, null, null, null, null);
         if (ArrayUtil.isNotEmpty(bpmnBytes)) {
             modelVO.setBpmnXml(BpmnModelUtils.getBpmnXml(bpmnBytes));
         }
@@ -72,7 +76,8 @@ public interface BpmModelConvert {
     default BpmModelRespVO buildModel0(Model model,
                                        BpmModelMetaInfoVO metaInfo, BpmFormDO form, BpmCategoryDO category,
                                        Deployment deployment, ProcessDefinition processDefinition,
-                                       List<AdminUserRespDTO> startUsers) {
+                                       List<AdminUserRespDTO> startUsers,
+                                       List<DeptRespDTO> startDepts) {
         BpmModelRespVO modelRespVO = new BpmModelRespVO().setId(model.getId()).setName(model.getName())
                 .setKey(model.getKey()).setCategory(model.getCategory())
                 .setCreateTime(DateUtils.of(model.getCreateTime()));
@@ -96,6 +101,8 @@ public interface BpmModelConvert {
         }
         // User
         modelRespVO.setStartUsers(BeanUtils.toBean(startUsers, UserSimpleBaseVO.class));
+        // Dept
+        modelRespVO.setStartDepts(BeanUtils.toBean(startDepts, DeptSimpleBaseVO.class));
         return modelRespVO;
     }
 

--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/dal/dataobject/definition/BpmProcessDefinitionInfoDO.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/dal/dataobject/definition/BpmProcessDefinitionInfoDO.java
@@ -152,6 +152,14 @@ public class BpmProcessDefinitionInfoDO extends BaseDO {
     private List<Long> startUserIds;
 
     /**
+     * 可发起部门编号数组
+     *
+     * 关联 {@link AdminUserRespDTO#getId()} 字段的数组
+     */
+    @TableField(typeHandler = LongListTypeHandler.class)
+    private List<Long> startDeptIds;
+
+    /**
      * 可管理用户编号数组
      *
      * 关联 {@link AdminUserRespDTO#getId()} 字段的数组

--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/service/definition/BpmProcessDefinitionServiceImpl.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/service/definition/BpmProcessDefinitionServiceImpl.java
@@ -12,6 +12,8 @@ import cn.iocoder.yudao.module.bpm.dal.dataobject.definition.BpmProcessDefinitio
 import cn.iocoder.yudao.module.bpm.dal.mysql.definition.BpmProcessDefinitionInfoMapper;
 import cn.iocoder.yudao.module.bpm.framework.flowable.core.enums.BpmnModelConstants;
 import cn.iocoder.yudao.module.bpm.framework.flowable.core.util.FlowableUtils;
+import cn.iocoder.yudao.module.system.api.user.AdminUserApi;
+import cn.iocoder.yudao.module.system.api.user.dto.AdminUserRespDTO;
 import jakarta.annotation.Resource;
 import lombok.extern.slf4j.Slf4j;
 import org.flowable.bpmn.model.BpmnModel;
@@ -49,6 +51,8 @@ public class BpmProcessDefinitionServiceImpl implements BpmProcessDefinitionServ
 
     @Resource
     private BpmProcessDefinitionInfoMapper processDefinitionMapper;
+    @Resource
+    private AdminUserApi adminUserApi;
 
     @Override
     public ProcessDefinition getProcessDefinition(String id) {
@@ -88,12 +92,23 @@ public class BpmProcessDefinitionServiceImpl implements BpmProcessDefinitionServ
         if (processDefinition == null) {
             return false;
         }
-        // 为空，则所有人都可以发起
-        if (CollUtil.isEmpty(processDefinition.getStartUserIds())) {
-            return true;
+
+        // 获取用户所在部门
+        AdminUserRespDTO user = adminUserApi.getUser(userId);
+        Long userDeptId = user != null ? user.getDeptId() : null;
+
+        // 校验用户是否在允许发起的用户列表中
+        if (!CollUtil.isEmpty(processDefinition.getStartUserIds())) {
+            return processDefinition.getStartUserIds().contains(userId);
         }
-        // 不为空，则需要存在里面
-        return processDefinition.getStartUserIds().contains(userId);
+
+        // 校验用户是否在允许发起的部门列表中
+        if (!CollUtil.isEmpty(processDefinition.getStartDeptIds()) && userDeptId != null) {
+            return processDefinition.getStartDeptIds().contains(userDeptId);
+        }
+
+        // 都为空，则所有人都可以发起
+        return true;
     }
 
     @Override


### PR DESCRIPTION
指定部门可以在部门新增成员后无需重新修改相关流程
前端代码也提了[pr139](https://github.com/yudaocode/yudao-ui-admin-vue3/pull/139)

表结构改动
```sql
alter table bpm_process_definition_info
    add start_dept_ids varchar(256) null comment '可发起部门编号数组';
```