### PR TITLE
[fix] 修复AI写作查询模型ID错误问题

### DIFF
--- a/yudao-module-ai/yudao-module-ai-biz/src/main/java/cn/iocoder/yudao/module/ai/service/write/AiWriteServiceImpl.java
+++ b/yudao-module-ai/yudao-module-ai-biz/src/main/java/cn/iocoder/yudao/module/ai/service/write/AiWriteServiceImpl.java
@@ -76,7 +76,7 @@ public class AiWriteServiceImpl implements AiWriteService {
                 ? writeRole.getSystemMessage() : AiChatRoleEnum.AI_WRITE_ROLE.getSystemMessage();
         // 1.3 校验平台
         AiPlatformEnum platform = AiPlatformEnum.validatePlatform(model.getPlatform());
-        StreamingChatModel chatModel = modalService.getChatModel(model.getKeyId());
+        StreamingChatModel chatModel = modalService.getChatModel(model.getId());
 
         // 2. 插入写作信息
         AiWriteDO writeDO = BeanUtils.toBean(generateReqVO, AiWriteDO.class, write -> write.setUserId(userId)


### PR DESCRIPTION
- ruoyi-vue-pro 版本：master
- 操作系统：win11
- 数据库：ruoyi-vue-pro

### 原因
AI写作功能debug使用报错
<img width="1098" alt="e9cf22804c1c5610a9b0387db072184d" src="https://github.com/user-attachments/assets/5073c940-be0c-4277-8158-a164e6e1a3f8" />
我发现原因是id使用错了，查询模型使用了查询akikey的Id

### 复现步骤
第一步：登录配置好模型
第二步：填写写作信息
第三步：等待生产写作内容

### 报错信息
<img width="1098" alt="e9cf22804c1c5610a9b0387db072184d" src="https://github.com/user-attachments/assets/5073c940-be0c-4277-8158-a164e6e1a3f8" />

修改成模板id后，即可成功进行写作
![image](https://github.com/user-attachments/assets/7432797f-c263-4700-8846-e72505d22746)
