### PR TITLE
修复退款通知中merchantRefundId字符串转换Long类型的问题

### DIFF
--- a/yudao-module-mall/yudao-module-trade/src/main/java/cn/iocoder/yudao/module/trade/controller/admin/aftersale/AfterSaleController.java
+++ b/yudao-module-mall/yudao-module-trade/src/main/java/cn/iocoder/yudao/module/trade/controller/admin/aftersale/AfterSaleController.java
@@ -141,8 +141,10 @@ public class AfterSaleController {
     public CommonResult<Boolean> updateAfterSaleRefunded(@RequestBody PayRefundNotifyReqDTO notifyReqDTO) {
         log.info("[updateAfterRefund][notifyReqDTO({})]", notifyReqDTO);
         if (StrUtil.startWithAny(notifyReqDTO.getMerchantRefundId(), "order-")) {
+            // 去掉 "order-" 前缀后转换为 Long
+            String orderIdStr = notifyReqDTO.getMerchantRefundId().substring(6); // "order-".length() = 6
             tradeOrderUpdateService.updatePaidOrderRefunded(
-                    Long.parseLong(notifyReqDTO.getMerchantRefundId()),
+                    Long.parseLong(orderIdStr),
                     notifyReqDTO.getPayRefundId());
         } else {
             afterSaleService.updateAfterSaleRefunded(

--- a/yudao-module-pay/src/main/java/cn/iocoder/yudao/module/pay/service/wallet/PayWalletRechargeServiceImpl.java
+++ b/yudao-module-pay/src/main/java/cn/iocoder/yudao/module/pay/service/wallet/PayWalletRechargeServiceImpl.java
@@ -186,7 +186,8 @@ public class PayWalletRechargeServiceImpl implements PayWalletRechargeService {
 
         // 3. 创建退款单
         String walletRechargeId = String.valueOf(id);
-        String refundId = walletRechargeId + "-refund";
+        // 钱包充值的退款ID直接使用充值记录ID，保持与校验逻辑一致
+        String refundId = walletRechargeId;
         Long payRefundId = payRefundApi.createRefund(new PayRefundCreateReqDTO()
                 .setAppKey(payProperties.getWalletPayAppKey()).setUserIp(userIp)
                 .setMerchantOrderId(walletRechargeId)


### PR DESCRIPTION
## 问题描述

在处理退款通知时，当`merchantRefundId`包含前缀时，直接调用`Long.parseLong()`会导致`NumberFormatException`异常。

## 修复内容

### 1. 售后订单退款通知处理
**文件**: `yudao-module-mall/yudao-module-trade/src/main/java/cn/iocoder/yudao/module/trade/controller/admin/aftersale/AfterSaleController.java`

**问题**: 当`merchantRefundId`以"order-"开头时（如"order-123"），直接调用`Long.parseLong()`会抛出异常。

**修复**: 在判断以"order-"开头后，先去掉前缀再转换为Long类型：
```java
if (StrUtil.startWithAny(notifyReqDTO.getMerchantRefundId(), "order-")) {
    // 去掉 "order-" 前缀后转换为 Long
    String orderIdStr = notifyReqDTO.getMerchantRefundId().substring(6); // "order-".length() = 6
    tradeOrderUpdateService.updatePaidOrderRefunded(
            Long.parseLong(orderIdStr),
            notifyReqDTO.getPayRefundId());
}
```

### 2. 钱包充值退款ID生成逻辑
**文件**: `yudao-module-pay/src/main/java/cn/iocoder/yudao/module/pay/service/wallet/PayWalletRechargeServiceImpl.java`

**问题**: 退款ID生成时使用`walletRechargeId + "-refund"`格式，但校验时期望纯数字，导致逻辑不一致。

**修复**: 统一退款ID格式，直接使用充值记录ID：
```java
// 钱包充值的退款ID直接使用充值记录ID，保持与校验逻辑一致
String refundId = walletRechargeId;
```

## 测试验证

- [x] 修复了售后订单退款通知中"order-"前缀的处理
- [x] 统一了钱包充值退款ID的生成和校验逻辑
- [x] 避免了NumberFormatException异常

## 影响范围

- 售后订单退款通知处理
- 钱包充值退款流程
- 支付模块退款回调处理

## 相关代码变更

1. `AfterSaleController.updateAfterSaleRefunded()` - 修复"order-"前缀处理
2. `PayWalletRechargeServiceImpl.refundWalletRecharge()` - 统一退款ID生成逻辑

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author