### PR TITLE
fix: 解决秒杀模块读取数据库优惠券时,类型转化异常

### DIFF
--- a/yudao-module-mall/yudao-module-trade/src/main/java/cn/iocoder/yudao/module/trade/dal/dataobject/order/JacksonMapTypeHandler.java
+++ b/yudao-module-mall/yudao-module-trade/src/main/java/cn/iocoder/yudao/module/trade/dal/dataobject/order/JacksonMapTypeHandler.java
@@ -1,0 +1,92 @@
+package cn.iocoder.yudao.module.trade.dal.dataobject.order;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.ibatis.type.BaseTypeHandler;
+import org.apache.ibatis.type.JdbcType;
+import org.apache.ibatis.type.MappedJdbcTypes;
+import org.apache.ibatis.type.MappedTypes;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+// 映射Java类型为Map
+@MappedTypes(Map.class)
+// 映射JDBC类型为VARCHAR(可根据实际情况调整)
+@MappedJdbcTypes(JdbcType.VARCHAR)
+@Slf4j
+public class JacksonMapTypeHandler extends BaseTypeHandler<Map<String, Object>> {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void setNonNullParameter(PreparedStatement ps, int i, Map<String, Object> parameter, JdbcType jdbcType) throws SQLException {
+        try {
+            // 将Map转换为JSON字符串
+            String json = objectMapper.writeValueAsString(parameter);
+            ps.setString(i, json);
+        } catch (Exception e) {
+            throw new SQLException("Error converting Map to JSON", e);
+        }
+    }
+
+    @Override
+    public Map<String, Object> getNullableResult(ResultSet rs, String columnName) throws SQLException {
+        return parseResult(rs, columnName, null);
+    }
+
+    @Override
+    public Map<String, Object> getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+        return parseResult(rs, null, columnIndex);
+    }
+
+    @Override
+    public Map<String, Object> getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+        String val = cs.getString(columnIndex);
+        // 从CallableStatement获取key的逻辑可能需要调整
+        String key = cs.getString(1); // 假设key在第1列
+        return buildResultMap(key, val);
+    }
+
+    private Map<String, Object> parseResult(ResultSet rs, String columnName, Integer columnIndex) throws SQLException {
+        String val = columnName != null ? rs.getString(columnName) : rs.getString(columnIndex);
+        // 修正：使用正确的索引获取key（假设key在第1列）
+        String key = rs.getString(1);
+        return buildResultMap(key, val);
+    }
+
+    private Map<String, Object> buildResultMap(String key, String value) {
+        if (key == null || value == null) {
+            return Collections.emptyMap();
+        }
+
+        try {
+            // 如果value是完整JSON，直接解析
+            if (value.startsWith("{") && value.endsWith("}")) {
+                Map<String, Object> map = objectMapper.readValue(value, new TypeReference<Map<String, Object>>() {});
+                map.put("id", key); // 将id添加到Map中
+                return map;
+            }
+            // 否则，创建简单的键值对
+            Map<String, Object> map = new HashMap<>();
+            map.put("id", key);
+            map.put("value", value);
+            return map;
+        } catch (Exception e) {
+            // 记录错误日志
+            log.error("Failed to parse JSON: {}", value, e);
+            // 返回包含原始数据的Map，避免异常导致流程中断
+            Map<String, Object> errorMap = new HashMap<>();
+            errorMap.put("id", key);
+            errorMap.put("rawValue", value);
+            errorMap.put("parseError", e.getMessage());
+            return errorMap;
+        }
+    }
+}    

--- a/yudao-module-mall/yudao-module-trade/src/main/java/cn/iocoder/yudao/module/trade/dal/dataobject/order/TradeOrderDO.java
+++ b/yudao-module-mall/yudao-module-trade/src/main/java/cn/iocoder/yudao/module/trade/dal/dataobject/order/TradeOrderDO.java
@@ -304,7 +304,7 @@ public class TradeOrderDO extends BaseDO {
      *
      * 目的：用于订单支付后赠送优惠券
      */
-    @TableField(typeHandler = JacksonTypeHandler.class)
+    @TableField(typeHandler = JaccksonMapTypeHandler.class)
     private Map<Long, Integer> giveCouponTemplateCounts;
     /**
      * 赠送的优惠劵编号

--- a/yudao-module-mall/yudao-module-trade/src/main/java/cn/iocoder/yudao/module/trade/service/price/calculator/TradePointActivityPriceCalculator.java
+++ b/yudao-module-mall/yudao-module-trade/src/main/java/cn/iocoder/yudao/module/trade/service/price/calculator/TradePointActivityPriceCalculator.java
@@ -56,7 +56,7 @@ public class TradePointActivityPriceCalculator implements TradePriceCalculator {
 
         Assert.isTrue(param.getItems().size() == 1, "积分商城兑换商品时，只允许选择一个商品");
         // 2. 校验是否可以参与积分商城活动
-        TradePriceCalculateRespBO.OrderItem orderItem = result.getItems().get(0);
+        TradePriceCalculateRespBO.OrderItem orderItem = result.getItems().getFirst();
         PointValidateJoinRespDTO activity = validateJoinPointActivity(
                 param.getUserId(), param.getPointActivityId(),
                 orderItem.getSkuId(), orderItem.getCount());


### PR DESCRIPTION
在秒杀模块中读取优惠卷src/main/java/cn/iocoder/yudao/module/trade/dal/dataobject/order/TradeOrderDO.java的    @TableField(typeHandler = JacksonTypeHandler.class)
    private Map<Long, Integer> giveCouponTemplateCounts;类型转化异常。
    
![image](https://github.com/user-attachments/assets/31379017-6fe5-4c31-aa52-cfe377ea6fdb)

    本次自定义JacksonMapTypeHandler方法。辅助整数类型转化为map属性。