### PR TITLE
fix: 修复创建流程分类时未初始化删除标识值

### DIFF
--- a/yudao-module-bpm/src/main/java/cn/iocoder/yudao/module/bpm/service/definition/BpmCategoryServiceImpl.java
+++ b/yudao-module-bpm/src/main/java/cn/iocoder/yudao/module/bpm/service/definition/BpmCategoryServiceImpl.java
@@ -41,6 +41,7 @@ public class BpmCategoryServiceImpl implements BpmCategoryService {
         validateCategoryCodeUnique(createReqVO);
         // 插入
         BpmCategoryDO category = BeanUtils.toBean(createReqVO, BpmCategoryDO.class);
+        category.setDeleted(false);
         bpmCategoryMapper.insert(category);
         return category.getId();
     }


### PR DESCRIPTION
创建流程分类时未设置删除标识的值，导致查询不到流程分类数据