### PR TITLE
fix：【system 系统功能】解决登录未禁用数据权限，前端带上旧token导致报错

### DIFF
--- a/yudao-module-system/src/main/java/cn/iocoder/yudao/module/system/service/auth/AdminAuthServiceImpl.java
+++ b/yudao-module-system/src/main/java/cn/iocoder/yudao/module/system/service/auth/AdminAuthServiceImpl.java
@@ -6,6 +6,7 @@ import cn.iocoder.yudao.framework.common.enums.UserTypeEnum;
 import cn.iocoder.yudao.framework.common.util.monitor.TracerUtils;
 import cn.iocoder.yudao.framework.common.util.servlet.ServletUtils;
 import cn.iocoder.yudao.framework.common.util.validation.ValidationUtils;
+import cn.iocoder.yudao.framework.datapermission.core.annotation.DataPermission;
 import cn.iocoder.yudao.module.system.api.logger.dto.LoginLogCreateReqDTO;
 import cn.iocoder.yudao.module.system.api.sms.SmsCodeApi;
 import cn.iocoder.yudao.module.system.api.sms.dto.code.SmsCodeUseReqDTO;
@@ -97,6 +98,7 @@ public class AdminAuthServiceImpl implements AdminAuthService {
     }
 
     @Override
+    @DataPermission(enable = false)
     public AuthLoginRespVO login(AuthLoginReqVO reqVO) {
         // 校验验证码
         validateCaptcha(reqVO);


### PR DESCRIPTION
用户反馈正确的账号密码报错账号密码不正确：
<img width="1119" height="155" alt="image" src="https://github.com/user-attachments/assets/1e11b026-abad-42ce-969f-2ab5bb1acd51" />
本地使用相同的账密一切正常，经过检查发现操作为：A用户登陆后不退出，打开登录页，输入B用户账密登录，前端带入A用户token时后台报错账密不正确。
检查代码原因为：
<img width="2000" height="898" alt="image" src="https://github.com/user-attachments/assets/85717d72-c1c5-4a2c-99be-72b53aad6f31" />
改为登录接口忽略数据权限即可。