### PR TITLE
feat(codegen): 支持 businessName 包含子目录

### DIFF
--- a/yudao-module-infra/src/main/java/cn/iocoder/yudao/module/infra/dal/dataobject/codegen/CodegenTableDO.java
+++ b/yudao-module-infra/src/main/java/cn/iocoder/yudao/module/infra/dal/dataobject/codegen/CodegenTableDO.java
@@ -7,6 +7,7 @@ import cn.iocoder.yudao.module.infra.enums.codegen.CodegenFrontTypeEnum;
 import cn.iocoder.yudao.module.infra.enums.codegen.CodegenSceneEnum;
 import cn.iocoder.yudao.module.infra.enums.codegen.CodegenTemplateTypeEnum;
 import com.baomidou.mybatisplus.annotation.KeySequence;
+import com.baomidou.mybatisplus.annotation.TableField;
 import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableName;
 import com.baomidou.mybatisplus.generator.config.po.TableInfo;
@@ -75,6 +76,15 @@ public class CodegenTableDO extends BaseDO {
      * 例如说，user、permission、dict 等等
      */
     private String businessName;
+    /**
+     * 业务名（用于包名）
+     * 将 businessName 中的 "/" 转换为 "."，用于 Java 包名
+     * 
+     * 例如说，purchase/requisition 转换为 purchase.requisition
+     * 注意：该字段为计算字段，不存储到数据库
+     */
+    @TableField(exist = false)
+    private String businessNameForPackage;
     /**
      * 类名称（首字母大写）
      *

--- a/yudao-module-infra/src/main/java/cn/iocoder/yudao/module/infra/service/codegen/inner/CodegenEngine.java
+++ b/yudao-module-infra/src/main/java/cn/iocoder/yudao/module/infra/service/codegen/inner/CodegenEngine.java
@@ -308,6 +308,13 @@ public class CodegenEngine {
      */
     public Map<String, String> execute(CodegenTableDO table, List<CodegenColumnDO> columns,
                                        List<CodegenTableDO> subTables, List<List<CodegenColumnDO>> subColumnsList) {
+        // 1.0 为 table 和 subTables 设置 businessNameForPackage
+        table.setBusinessNameForPackage(table.getBusinessName().replaceAll("/", "\\."));
+        if (CollUtil.isNotEmpty(subTables)) {
+            subTables.forEach(subTable -> 
+                subTable.setBusinessNameForPackage(subTable.getBusinessName().replaceAll("/", "\\.")));
+        }
+        
         // 1.1 初始化 bindMap 上下文
         Map<String, Object> bindingMap = initBindingMap(table, columns, subTables, subColumnsList);
         // 1.2 获得模版
@@ -546,13 +553,17 @@ public class CodegenEngine {
         filePath = StrUtil.replace(filePath, "${table.moduleName}", table.getModuleName());
         filePath = StrUtil.replace(filePath, "${table.businessName}", table.getBusinessName());
         filePath = StrUtil.replace(filePath, "${table.className}", table.getClassName());
+        filePath = StrUtil.replace(filePath, "${table.businessNameForPackage}", table.getBusinessNameForPackage());
         // 特殊：主子表专属逻辑
         Integer subIndex = (Integer) bindingMap.get("subIndex");
         if (subIndex != null) {
-            CodegenTableDO subTable = ((List<CodegenTableDO>) bindingMap.get("subTables")).get(subIndex);
+            @SuppressWarnings("unchecked")
+            List<CodegenTableDO> subTables = (List<CodegenTableDO>) bindingMap.get("subTables");
+            CodegenTableDO subTable = subTables.get(subIndex);
             filePath = StrUtil.replace(filePath, "${subTable.moduleName}", subTable.getModuleName());
             filePath = StrUtil.replace(filePath, "${subTable.businessName}", subTable.getBusinessName());
             filePath = StrUtil.replace(filePath, "${subTable.className}", subTable.getClassName());
+            filePath = StrUtil.replace(filePath, "${subTable.businessNameForPackage}", subTable.getBusinessNameForPackage());
             filePath = StrUtil.replace(filePath, "${subSimpleClassName}",
                     ((List<String>) bindingMap.get("subSimpleClassNames")).get(subIndex));
             filePath = StrUtil.replace(filePath, "${subSimpleClassName_strikeCase}",
@@ -655,3 +666,4 @@ public class CodegenEngine {
     }
 
 }
+

--- a/yudao-module-infra/src/main/resources/codegen/java/controller/controller.vm
+++ b/yudao-module-infra/src/main/resources/codegen/java/controller/controller.vm
@@ -1,4 +1,4 @@
-package ${basePackage}.module.${table.moduleName}.controller.${sceneEnum.basePackage}.${table.businessName};
+package ${basePackage}.module.${table.moduleName}.controller.${sceneEnum.basePackage}.${table.businessNameForPackage};
 
 import org.springframework.web.bind.annotation.*;
 import ${jakartaPackage}.annotation.Resource;
@@ -26,13 +26,13 @@ import ${ExcelUtilsClassName};
 import ${ApiAccessLogClassName};
 import static ${OperateTypeEnumClassName}.*;
 
-import ${basePackage}.module.${table.moduleName}.controller.${sceneEnum.basePackage}.${table.businessName}.vo.*;
-import ${basePackage}.module.${table.moduleName}.dal.dataobject.${table.businessName}.${table.className}DO;
+import ${basePackage}.module.${table.moduleName}.controller.${sceneEnum.basePackage}.${table.businessNameForPackage}.vo.*;
+import ${basePackage}.module.${table.moduleName}.dal.dataobject.${table.businessNameForPackage}.${table.className}DO;
 ## 特殊：主子表专属逻辑
 #foreach ($subTable in $subTables)
-import ${basePackage}.module.${subTable.moduleName}.dal.dataobject.${subTable.businessName}.${subTable.className}DO;
+import ${basePackage}.module.${subTable.moduleName}.dal.dataobject.${subTable.businessNameForPackage}.${subTable.className}DO;
 #end
-import ${basePackage}.module.${table.moduleName}.service.${table.businessName}.${table.className}Service;
+import ${basePackage}.module.${table.moduleName}.service.${table.businessNameForPackage}.${table.className}Service;
 
 @Tag(name = "${sceneEnum.name} - ${table.classComment}")
 @RestController

--- a/yudao-module-infra/src/main/resources/codegen/java/controller/vo/listReqVO.vm
+++ b/yudao-module-infra/src/main/resources/codegen/java/controller/vo/listReqVO.vm
@@ -1,4 +1,4 @@
-package ${basePackage}.module.${table.moduleName}.controller.${sceneEnum.basePackage}.${table.businessName}.vo;
+package ${basePackage}.module.${table.moduleName}.controller.${sceneEnum.basePackage}.${table.businessNameForPackage}.vo;
 
 import lombok.*;
 import java.util.*;

--- a/yudao-module-infra/src/main/resources/codegen/java/controller/vo/pageReqVO.vm
+++ b/yudao-module-infra/src/main/resources/codegen/java/controller/vo/pageReqVO.vm
@@ -1,4 +1,4 @@
-package ${basePackage}.module.${table.moduleName}.controller.${sceneEnum.basePackage}.${table.businessName}.vo;
+package ${basePackage}.module.${table.moduleName}.controller.${sceneEnum.basePackage}.${table.businessNameForPackage}.vo;
 
 import lombok.*;
 import java.util.*;

--- a/yudao-module-infra/src/main/resources/codegen/java/controller/vo/respVO.vm
+++ b/yudao-module-infra/src/main/resources/codegen/java/controller/vo/respVO.vm
@@ -1,4 +1,4 @@
-package ${basePackage}.module.${table.moduleName}.controller.${sceneEnum.basePackage}.${table.businessName}.vo;
+package ${basePackage}.module.${table.moduleName}.controller.${sceneEnum.basePackage}.${table.businessNameForPackage}.vo;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;

--- a/yudao-module-infra/src/main/resources/codegen/java/controller/vo/saveReqVO.vm
+++ b/yudao-module-infra/src/main/resources/codegen/java/controller/vo/saveReqVO.vm
@@ -1,4 +1,4 @@
-package ${basePackage}.module.${table.moduleName}.controller.${sceneEnum.basePackage}.${table.businessName}.vo;
+package ${basePackage}.module.${table.moduleName}.controller.${sceneEnum.basePackage}.${table.businessNameForPackage}.vo;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
@@ -21,7 +21,7 @@ import java.time.LocalDateTime;
 #end
 ## 特殊：主子表专属逻辑
 #foreach ($subTable in $subTables)
-import ${basePackage}.module.${subTable.moduleName}.dal.dataobject.${subTable.businessName}.${subTable.className}DO;
+import ${basePackage}.module.${subTable.moduleName}.dal.dataobject.${subTable.businessNameForPackage}.${subTable.className}DO;
 #end
 
 @Schema(description = "${sceneEnum.name} - ${table.classComment}新增/修改 Request VO")

--- a/yudao-module-infra/src/main/resources/codegen/java/dal/do.vm
+++ b/yudao-module-infra/src/main/resources/codegen/java/dal/do.vm
@@ -1,4 +1,4 @@
-package ${basePackage}.module.${table.moduleName}.dal.dataobject.${table.businessName};
+package ${basePackage}.module.${table.moduleName}.dal.dataobject.${table.businessNameForPackage};
 
 import lombok.*;
 import java.util.*;

--- a/yudao-module-infra/src/main/resources/codegen/java/dal/do_sub.vm
+++ b/yudao-module-infra/src/main/resources/codegen/java/dal/do_sub.vm
@@ -1,6 +1,6 @@
 #set ($subTable = $subTables.get($subIndex))##当前表
 #set ($subColumns = $subColumnsList.get($subIndex))##当前字段数组
-package ${basePackage}.module.${subTable.moduleName}.dal.dataobject.${subTable.businessName};
+package ${basePackage}.module.${subTable.moduleName}.dal.dataobject.${subTable.businessNameForPackage};
 
 import lombok.*;
 import java.util.*;

--- a/yudao-module-infra/src/main/resources/codegen/java/dal/mapper.vm
+++ b/yudao-module-infra/src/main/resources/codegen/java/dal/mapper.vm
@@ -1,13 +1,13 @@
-package ${basePackage}.module.${table.moduleName}.dal.mysql.${table.businessName};
+package ${basePackage}.module.${table.moduleName}.dal.mysql.${table.businessNameForPackage};
 
 import java.util.*;
 
 import ${PageResultClassName};
 import ${QueryWrapperClassName};
 import ${BaseMapperClassName};
-import ${basePackage}.module.${table.moduleName}.dal.dataobject.${table.businessName}.${table.className}DO;
+import ${basePackage}.module.${table.moduleName}.dal.dataobject.${table.businessNameForPackage}.${table.className}DO;
 import org.apache.ibatis.annotations.Mapper;
-import ${basePackage}.module.${table.moduleName}.controller.${sceneEnum.basePackage}.${table.businessName}.vo.*;
+import ${basePackage}.module.${table.moduleName}.controller.${sceneEnum.basePackage}.${table.businessNameForPackage}.vo.*;
 
 ## 字段模板
 #macro(listCondition)

--- a/yudao-module-infra/src/main/resources/codegen/java/dal/mapper.xml.vm
+++ b/yudao-module-infra/src/main/resources/codegen/java/dal/mapper.xml.vm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="${basePackage}.module.${table.moduleName}.dal.mysql.${table.businessName}.${table.className}Mapper">
+<mapper namespace="${basePackage}.module.${table.moduleName}.dal.mysql.${table.businessNameForPackage}.${table.className}Mapper">
 
     <!--
         一般情况下，尽可能使用 Mapper 进行 CRUD 增删改查即可。

--- a/yudao-module-infra/src/main/resources/codegen/java/dal/mapper_sub.vm
+++ b/yudao-module-infra/src/main/resources/codegen/java/dal/mapper_sub.vm
@@ -2,7 +2,7 @@
 #set ($subColumns = $subJoinColumnsList.get($subIndex))##当前字段数组
 #set ($subJoinColumn = $subJoinColumns.get($subIndex))##当前 join 字段
 #set ($SubJoinColumnName = $subJoinColumn.javaField.substring(0,1).toUpperCase() + ${subJoinColumn.javaField.substring(1)})##首字母大写
-package ${basePackage}.module.${subTable.moduleName}.dal.mysql.${subTable.businessName};
+package ${basePackage}.module.${subTable.moduleName}.dal.mysql.${subTable.businessNameForPackage};
 
 import java.util.*;
 
@@ -10,7 +10,7 @@ import ${PageResultClassName};
 import ${PageParamClassName};
 import ${QueryWrapperClassName};
 import ${BaseMapperClassName};
-import ${basePackage}.module.${subTable.moduleName}.dal.dataobject.${subTable.businessName}.${subTable.className}DO;
+import ${basePackage}.module.${subTable.moduleName}.dal.dataobject.${subTable.businessNameForPackage}.${subTable.className}DO;
 import org.apache.ibatis.annotations.Mapper;
 
 /**

--- a/yudao-module-infra/src/main/resources/codegen/java/service/service.vm
+++ b/yudao-module-infra/src/main/resources/codegen/java/service/service.vm
@@ -1,12 +1,12 @@
-package ${basePackage}.module.${table.moduleName}.service.${table.businessName};
+package ${basePackage}.module.${table.moduleName}.service.${table.businessNameForPackage};
 
 import java.util.*;
 import ${jakartaPackage}.validation.*;
-import ${basePackage}.module.${table.moduleName}.controller.${sceneEnum.basePackage}.${table.businessName}.vo.*;
-import ${basePackage}.module.${table.moduleName}.dal.dataobject.${table.businessName}.${table.className}DO;
+import ${basePackage}.module.${table.moduleName}.controller.${sceneEnum.basePackage}.${table.businessNameForPackage}.vo.*;
+import ${basePackage}.module.${table.moduleName}.dal.dataobject.${table.businessNameForPackage}.${table.className}DO;
 ## 特殊：主子表专属逻辑
 #foreach ($subTable in $subTables)
-import ${basePackage}.module.${subTable.moduleName}.dal.dataobject.${subTable.businessName}.${subTable.className}DO;
+import ${basePackage}.module.${subTable.moduleName}.dal.dataobject.${subTable.businessNameForPackage}.${subTable.className}DO;
 #end
 import ${PageResultClassName};
 import ${PageParamClassName};

--- a/yudao-module-infra/src/main/resources/codegen/java/service/serviceImpl.vm
+++ b/yudao-module-infra/src/main/resources/codegen/java/service/serviceImpl.vm
@@ -1,27 +1,28 @@
-package ${basePackage}.module.${table.moduleName}.service.${table.businessName};
+package ${basePackage}.module.${table.moduleName}.service.${table.businessNameForPackage};
 
 import cn.hutool.core.collection.CollUtil;
+import cn.hutool.core.util.ObjectUtil;
 import org.springframework.stereotype.Service;
 import ${jakartaPackage}.annotation.Resource;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
-import ${basePackage}.module.${table.moduleName}.controller.${sceneEnum.basePackage}.${table.businessName}.vo.*;
-import ${basePackage}.module.${table.moduleName}.dal.dataobject.${table.businessName}.${table.className}DO;
+import ${basePackage}.module.${table.moduleName}.controller.${sceneEnum.basePackage}.${table.businessNameForPackage}.vo.*;
+import ${basePackage}.module.${table.moduleName}.dal.dataobject.${table.businessNameForPackage}.${table.className}DO;
 ## 特殊：主子表专属逻辑
 #foreach ($subTable in $subTables)
-import ${basePackage}.module.${subTable.moduleName}.dal.dataobject.${subTable.businessName}.${subTable.className}DO;
+import ${basePackage}.module.${subTable.moduleName}.dal.dataobject.${subTable.businessNameForPackage}.${subTable.className}DO;
 #end
 import ${PageResultClassName};
 import ${PageParamClassName};
 import ${BeanUtils};
 
-import ${basePackage}.module.${table.moduleName}.dal.mysql.${table.businessName}.${table.className}Mapper;
+import ${basePackage}.module.${table.moduleName}.dal.mysql.${table.businessNameForPackage}.${table.className}Mapper;
 ## 特殊：主子表专属逻辑
 #foreach ($subTable in $subTables)
 #set ($index = $foreach.count - 1)
-import ${basePackage}.module.${subTable.moduleName}.dal.mysql.${subTable.businessName}.${subTable.className}Mapper;
+import ${basePackage}.module.${subTable.moduleName}.dal.mysql.${subTable.businessNameForPackage}.${subTable.className}Mapper;
 #end
 
 import static ${ServiceExceptionUtilClassName}.exception;

--- a/yudao-module-infra/src/main/resources/codegen/java/test/serviceTest.vm
+++ b/yudao-module-infra/src/main/resources/codegen/java/test/serviceTest.vm
@@ -1,4 +1,4 @@
-package ${basePackage}.module.${table.moduleName}.service.${table.businessName};
+package ${basePackage}.module.${table.moduleName}.service.${table.businessNameForPackage};
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -7,9 +7,9 @@ import ${jakartaPackage}.annotation.Resource;
 
 import ${baseFrameworkPackage}.test.core.ut.BaseDbUnitTest;
 
-import ${basePackage}.module.${table.moduleName}.controller.${sceneEnum.basePackage}.${table.businessName}.vo.*;
-import ${basePackage}.module.${table.moduleName}.dal.dataobject.${table.businessName}.${table.className}DO;
-import ${basePackage}.module.${table.moduleName}.dal.mysql.${table.businessName}.${table.className}Mapper;
+import ${basePackage}.module.${table.moduleName}.controller.${sceneEnum.basePackage}.${table.businessNameForPackage}.vo.*;
+import ${basePackage}.module.${table.moduleName}.dal.dataobject.${table.businessNameForPackage}.${table.className}DO;
+import ${basePackage}.module.${table.moduleName}.dal.mysql.${table.businessNameForPackage}.${table.className}Mapper;
 import ${PageResultClassName};
 
 import ${jakartaPackage}.annotation.Resource;


### PR DESCRIPTION
需求：代码生成时支持 businessName 使用 '/' 作为子目录分隔符（如 purchase/requisition） 结果：在生成的 Java 代码中，package 和 import 语句自动将 '/' 转换为 '.'（如 purchase.requisition）

- 在 CodegenTableDO 新增 businessNameForPackage 字段（计算字段，不存储数据库）
- 在代码生成入口统一设置 table 和 subTables 的 businessNameForPackage
- 所有 VM 模板统一使用 \${table.businessNameForPackage} 和 \${subTable.businessNameForPackage}