### PR TITLE
quartz定时任务失效问题

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
             <dependency>
                 <groupId>org.quartz-scheduler</groupId>
                 <artifactId>quartz</artifactId>
-                <version>2.5.0</version>
+                <version>2.5.2</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
项目依赖自动使用了Quartz  2.5.1，满足以下条件
Quartz  2.5.1
数据库 PostgreSQL
这正好踩中了 Quartz 官方刚刚认领的一个 bug：
在 2.5.1 里，引入了新的 Util.areNull/containsColumnNames，对 ResultSet 里的列名用大小写敏感比较，
而 PostgreSQL 把列名全变成小写，结果就导致：
明明库里有 trigger 记录，代码却觉得「没有」，抛 NoRecordFoundException导致无法调度，进而定时任务失效

通过把Quartz 版本更新到2.5.2解决定时任务失效问题