### PR TITLE
fix(infra): 修正定时任务日志状态字典格式引用

### DIFF
--- a/yudao-module-infra/src/main/java/cn/iocoder/yudao/module/infra/controller/admin/job/vo/log/JobLogRespVO.java
+++ b/yudao-module-infra/src/main/java/cn/iocoder/yudao/module/infra/controller/admin/job/vo/log/JobLogRespVO.java
@@ -49,7 +49,7 @@ public class JobLogRespVO {
 
     @Schema(description = "任务状态，参见 JobLogStatusEnum 枚举", requiredMode = Schema.RequiredMode.REQUIRED, example = "1")
     @ExcelProperty(value = "任务状态", converter = DictConvert.class)
-    @DictFormat(DictTypeConstants.JOB_STATUS)
+    @DictFormat(DictTypeConstants.JOB_LOG_STATUS)
     private Integer status;
 
     @Schema(description = "结果数据", example = "执行成功")


### PR DESCRIPTION
将定时任务日志状态字段的字典格式引用从 JOB_STATUS 更改为 JOB_LOG_STATUS
确保定时任务日志状态导出excel时映射到正确的名称