### PR TITLE
不需要再分别配置 <source> 和 <target>，直接使用 <release> 属性

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,8 +35,7 @@
         <revision>2025.12-SNAPSHOT</revision>
         <!-- Maven 相关 -->
         <java.version>17</java.version>
-        <maven.compiler.source>${java.version}</maven.compiler.source>
-        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <maven.compiler.release>${java.version}</maven.compiler.release>
         <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
         <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
         <flatten-maven-plugin.version>1.7.2</flatten-maven-plugin.version>


### PR DESCRIPTION
1. 签名检查（Signature Checking）的问题 
传统的 -source 和 -target 组合存在一个“安全漏洞”：
-source：仅检查代码语法是否符合 Java 17。
-target：仅决定生成的 JVM 字节码版本。
致命缺点：编译器默认链接的是当前正在使用的 JDK 的标准库（RT.jar 或 modules）。如果你用 JDK 21 编译，即使指定了 target 为 17，代码里如果误用了 JDK 21 新增的方法，编译依然会通过，但发布到 JDK 17 环境就会崩溃。

2. --release 的自动化优势 --release 17 相当于同时完成了三件事：
设置 -source 17。
设置 -target 17。
自动设置 --system 模块路径：它会让编译器链接到目标版本（Java 17）的 API 定义，而不是当前 JDK 的 API。