### PR TITLE
  feat(infra): 代码生成器为后端和 Vue3 模板添加 Excel 导入功能

### DIFF
--- a/yudao-module-infra/src/main/java/cn/iocoder/yudao/module/infra/service/codegen/inner/CodegenEngine.java
+++ b/yudao-module-infra/src/main/java/cn/iocoder/yudao/module/infra/service/codegen/inner/CodegenEngine.java
@@ -72,6 +72,8 @@ public class CodegenEngine {
             .put(javaTemplatePath("controller/vo/listReqVO"), javaModuleImplVOFilePath("ListReqVO"))
             .put(javaTemplatePath("controller/vo/respVO"), javaModuleImplVOFilePath("RespVO"))
             .put(javaTemplatePath("controller/vo/saveReqVO"), javaModuleImplVOFilePath("SaveReqVO"))
+            .put(javaTemplatePath("controller/vo/importExcelVO"), javaModuleImplVOFilePath("ImportExcelVO"))
+            .put(javaTemplatePath("controller/vo/importRespVO"), javaModuleImplVOFilePath("ImportRespVO"))
             .put(javaTemplatePath("controller/controller"), javaModuleImplControllerFilePath())
             .put(javaTemplatePath("dal/do"),
                     javaModuleImplMainFilePath("dal/dataobject/${table.businessName}/${table.className}DO"))

--- a/yudao-module-infra/src/main/resources/codegen/java/controller/controller.vm
+++ b/yudao-module-infra/src/main/resources/codegen/java/controller/controller.vm
@@ -1,6 +1,7 @@
 package ${basePackage}.module.${table.moduleName}.controller.${sceneEnum.basePackage}.${table.businessName};
 
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import ${jakartaPackage}.annotation.Resource;
 import org.springframework.validation.annotation.Validated;
 #if ($sceneEnum.scene == 1)import org.springframework.security.access.prepost.PreAuthorize;#end
@@ -159,6 +160,28 @@ public class ${sceneEnum.prefixClass}${table.className}Controller {
                         BeanUtils.toBean(list, ${table.className}RespVO.class));
     }
 #end
+
+    @GetMapping("/get-import-template")
+    @Operation(summary = "获得导入${table.classComment}模板")
+#if ($sceneEnum.scene == 1)
+    @PreAuthorize("@ss.hasPermission('${permissionPrefix}:import')")
+#end
+    public void import${simpleClassName}Template(HttpServletResponse response) throws IOException {
+        ExcelUtils.write(response, "${table.classComment}导入模板.xls", "数据",
+                ${sceneEnum.prefixClass}${table.className}ImportExcelVO.class, Collections.emptyList());
+    }
+
+    @PostMapping("/import")
+    @Operation(summary = "导入${table.classComment}")
+    @Parameter(name = "file", description = "Excel 文件", required = true)
+#if ($sceneEnum.scene == 1)
+    @PreAuthorize("@ss.hasPermission('${permissionPrefix}:import')")
+#end
+    @ApiAccessLog(operateType = IMPORT)
+    public CommonResult<${sceneEnum.prefixClass}${table.className}ImportRespVO> import${simpleClassName}(@RequestParam("file") MultipartFile file) throws Exception {
+        List<${sceneEnum.prefixClass}${table.className}ImportExcelVO> list = ExcelUtils.read(file, ${sceneEnum.prefixClass}${table.className}ImportExcelVO.class);
+        return success(${classNameVar}Service.import${simpleClassName}List(list));
+    }
 
 ## 特殊：主子表专属逻辑
 #foreach ($subTable in $subTables)

--- a/yudao-module-infra/src/main/resources/codegen/java/controller/vo/importExcelVO.vm
+++ b/yudao-module-infra/src/main/resources/codegen/java/controller/vo/importExcelVO.vm
@@ -1,0 +1,38 @@
+package ${basePackage}.module.${table.moduleName}.controller.${sceneEnum.basePackage}.${table.businessName}.vo;
+
+import cn.idev.excel.annotation.ExcelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+#foreach ($column in $columns)
+#if (${column.createOperation} && "$!column.dictType" != "")
+import ${DictFormatClassName};
+import ${DictConvertClassName};
+#break
+#end
+#end
+
+/**
+ * ${table.classComment} Excel 导入 VO
+ */
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ${sceneEnum.prefixClass}${table.className}ImportExcelVO {
+
+## 逐个处理字段
+#foreach ($column in $columns)
+#if (${column.createOperation})
+#if ("$!column.dictType" != "")
+    @ExcelProperty(value = "${column.columnComment}", converter = DictConvert.class)
+    @DictFormat("${column.dictType}") // TODO 代码优化：建议设置到对应的 DictTypeConstants 枚举类中
+#else
+    @ExcelProperty("${column.columnComment}")
+#end
+    private ${column.javaType} ${column.javaField};
+
+#end
+#end
+}

--- a/yudao-module-infra/src/main/resources/codegen/java/controller/vo/importRespVO.vm
+++ b/yudao-module-infra/src/main/resources/codegen/java/controller/vo/importRespVO.vm
@@ -1,0 +1,23 @@
+package ${basePackage}.module.${table.moduleName}.controller.${sceneEnum.basePackage}.${table.businessName}.vo;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.Map;
+
+@Schema(description = "${sceneEnum.name} - ${table.classComment}导入 Response VO")
+@Data
+@Builder
+public class ${sceneEnum.prefixClass}${table.className}ImportRespVO {
+
+    @Schema(description = "创建成功的数量", requiredMode = Schema.RequiredMode.REQUIRED, example = "10")
+    private Integer successCount;
+
+    @Schema(description = "导入失败的数量", requiredMode = Schema.RequiredMode.REQUIRED, example = "1")
+    private Integer failureCount;
+
+    @Schema(description = "导入失败的数据集合，key 为行号，value 为失败原因", requiredMode = Schema.RequiredMode.REQUIRED)
+    private Map<Integer, String> failureRows;
+
+}

--- a/yudao-module-infra/src/main/resources/codegen/java/service/service.vm
+++ b/yudao-module-infra/src/main/resources/codegen/java/service/service.vm
@@ -27,6 +27,14 @@ public interface ${table.className}Service {
     ${primaryColumn.javaType} create${simpleClassName}(@Valid ${saveReqVOClass} ${saveReqVOVar});
 
     /**
+     * 导入${table.classComment}
+     *
+     * @param importList 导入信息
+     * @return 导入结果
+     */
+    ${sceneEnum.prefixClass}${table.className}ImportRespVO import${simpleClassName}List(List<${sceneEnum.prefixClass}${table.className}ImportExcelVO> importList);
+
+    /**
      * 更新${table.classComment}
      *
      * @param ${updateReqVOVar} 更新信息

--- a/yudao-module-infra/src/main/resources/codegen/java/service/serviceImpl.vm
+++ b/yudao-module-infra/src/main/resources/codegen/java/service/serviceImpl.vm
@@ -112,7 +112,7 @@ public class ${table.className}ServiceImpl implements ${table.className}Service 
                 create${simpleClassName}(BeanUtils.toBean(importItem, ${saveReqVOClass}.class));
                 successCount.incrementAndGet();
             } catch (Exception ex) {
-                failureRows.put(currentIndex, ex.getMessage());
+                failureRows.put(currentIndex, resolveImportFailureMessage(ex));
             }
         });
         return ${sceneEnum.prefixClass}${table.className}ImportRespVO.builder()
@@ -120,6 +120,17 @@ public class ${table.className}ServiceImpl implements ${table.className}Service 
                 .failureCount(failureRows.size())
                 .failureRows(failureRows)
                 .build();
+    }
+
+    /**
+     * 仅返回根因异常信息，避免把 MyBatis 长堆栈直接暴露给前端。
+     */
+    private String resolveImportFailureMessage(Exception ex) {
+        Throwable root = ex;
+        while (root.getCause() != null && root.getCause() != root) {
+            root = root.getCause();
+        }
+        return root.getMessage() != null ? root.getMessage() : ex.getMessage();
     }
 
     @Override

--- a/yudao-module-infra/src/main/resources/codegen/java/service/serviceImpl.vm
+++ b/yudao-module-infra/src/main/resources/codegen/java/service/serviceImpl.vm
@@ -7,6 +7,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
 import ${basePackage}.module.${table.moduleName}.controller.${sceneEnum.basePackage}.${table.businessName}.vo.*;
 import ${basePackage}.module.${table.moduleName}.dal.dataobject.${table.businessName}.${table.className}DO;
 ## 特殊：主子表专属逻辑
@@ -90,6 +91,35 @@ public class ${table.className}ServiceImpl implements ${table.className}Service 
 #end
         // 返回
         return ${classNameVar}.getId();
+    }
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public ${sceneEnum.prefixClass}${table.className}ImportRespVO import${simpleClassName}List(List<${sceneEnum.prefixClass}${table.className}ImportExcelVO> importList) {
+        if (CollUtil.isEmpty(importList)) {
+            return ${sceneEnum.prefixClass}${table.className}ImportRespVO.builder()
+                    .successCount(0)
+                    .failureCount(0)
+                    .failureRows(new LinkedHashMap<>())
+                    .build();
+        }
+        AtomicInteger successCount = new AtomicInteger();
+        Map<Integer, String> failureRows = new LinkedHashMap<>();
+        AtomicInteger index = new AtomicInteger(1);
+        importList.forEach(importItem -> {
+            int currentIndex = index.getAndIncrement();
+            try {
+                create${simpleClassName}(BeanUtils.toBean(importItem, ${saveReqVOClass}.class));
+                successCount.incrementAndGet();
+            } catch (Exception ex) {
+                failureRows.put(currentIndex, ex.getMessage());
+            }
+        });
+        return ${sceneEnum.prefixClass}${table.className}ImportRespVO.builder()
+                .successCount(successCount.get())
+                .failureCount(failureRows.size())
+                .failureRows(failureRows)
+                .build();
     }
 
     @Override
@@ -359,6 +389,9 @@ public class ${table.className}ServiceImpl implements ${table.className}Service 
 #else
     #if ( $subTable.subJoinMany)
     private void create${subSimpleClassName}List(${primaryColumn.javaType} ${subJoinColumn.javaField}, List<${subTable.className}DO> list) {
+        if (CollUtil.isEmpty(list)) {
+            return;
+        }
         list.forEach(o -> o.set${SubJoinColumnName}(${subJoinColumn.javaField}).clean());
         ${subClassNameVars.get($index)}Mapper.insertBatch(list);
     }

--- a/yudao-module-infra/src/main/resources/codegen/sql/sql.vm
+++ b/yudao-module-infra/src/main/resources/codegen/sql/sql.vm
@@ -1,6 +1,6 @@
 ## 通用变量定义
-#set ($functionNames = ['查询', '创建', '更新', '删除', '导出'])
-#set ($functionOps = ['query', 'create', 'update', 'delete', 'export'])
+#set ($functionNames = ['查询', '创建', '更新', '删除', '导出', '导入'])
+#set ($functionOps = ['query', 'create', 'update', 'delete', 'export', 'import'])
 ##
 ## 宏定义：生成按钮 SQL（通用部分）
 #macro(insertButtonSql $parentIdVar)

--- a/yudao-module-infra/src/main/resources/codegen/vue3/api/api.ts.vm
+++ b/yudao-module-infra/src/main/resources/codegen/vue3/api/api.ts.vm
@@ -98,6 +98,16 @@ export const ${simpleClassName}Api = {
   export${simpleClassName}: async (params) => {
     return await request.download({ url: `${baseURL}/export-excel`, params })
   },
+
+  // 下载${table.classComment}导入模板
+  import${simpleClassName}Template: async () => {
+    return await request.download({ url: `${baseURL}/get-import-template` })
+  },
+
+  // 导入${table.classComment}
+  import${simpleClassName}: async (data: FormData) => {
+    return await request.upload({ url: `${baseURL}/import`, data })
+  },
 ## 特殊：主子表专属逻辑
 #foreach ($subTable in $subTables)
 #set ($index = $foreach.count - 1)

--- a/yudao-module-infra/src/main/resources/codegen/vue3/views/index.vue.vm
+++ b/yudao-module-infra/src/main/resources/codegen/vue3/views/index.vue.vm
@@ -93,6 +93,14 @@
           <Icon icon="ep:plus" class="mr-5px" /> 新增
         </el-button>
         <el-button
+          type="warning"
+          plain
+          @click="handleImport"
+          v-hasPermi="['${permissionPrefix}:import']"
+        >
+          <Icon icon="ep:upload" class="mr-5px" /> 导入
+        </el-button>
+        <el-button
           type="success"
           plain
           @click="handleExport"
@@ -238,6 +246,43 @@
     />
   </ContentWrap>
 
+  <!-- 导入弹窗 -->
+  <Dialog v-model="importDialogVisible" title="${table.classComment}导入" width="400">
+    <el-upload
+      ref="uploadRef"
+      v-model:file-list="fileList"
+      :auto-upload="false"
+      :disabled="importFormLoading"
+      :limit="1"
+      :on-exceed="handleImportExceed"
+      accept=".xlsx, .xls"
+      action="none"
+      drag
+    >
+      <Icon icon="ep:upload" />
+      <div class="el-upload__text">将文件拖到此处，或<em>点击上传</em></div>
+      <template #tip>
+        <div class="el-upload__tip text-center">
+          <span>仅允许导入 xls、xlsx 格式文件。</span>
+          <el-link
+            :underline="false"
+            style="font-size: 12px; vertical-align: baseline"
+            type="primary"
+            @click="handleImportTemplate"
+          >
+            下载模板
+          </el-link>
+        </div>
+      </template>
+    </el-upload>
+    <template #footer>
+      <el-button :disabled="importFormLoading" type="primary" @click="submitImportForm">
+        确 定
+      </el-button>
+      <el-button @click="importDialogVisible = false">取 消</el-button>
+    </template>
+  </Dialog>
+
   <!-- 表单弹窗：添加/修改 -->
   <${simpleClassName}Form ref="formRef" @success="getList" />
 ## 特殊：主子表专属逻辑
@@ -263,6 +308,7 @@
 import { getIntDictOptions, getStrDictOptions, getBoolDictOptions, DICT_TYPE } from '@/utils/dict'
 import { isEmpty } from '@/utils/is'
 import { dateFormatter } from '@/utils/formatTime'
+import type { UploadUserFile } from 'element-plus'
 ## 特殊：树表专属逻辑
 #if ( $table.templateType == 2 )
 import { handleTree } from '@/utils/tree'
@@ -308,6 +354,10 @@ const queryParams = reactive({
 })
 const queryFormRef = ref() // 搜索的表单
 const exportLoading = ref(false) // 导出的加载中
+const importDialogVisible = ref(false) // 导入弹窗
+const importFormLoading = ref(false) // 导入的加载中
+const uploadRef = ref()
+const fileList = ref<UploadUserFile[]>([])
 
 /** 查询列表 */
 const getList = async () => {
@@ -343,6 +393,58 @@ const resetQuery = () => {
 const formRef = ref()
 const openForm = (type: string, id?: number) => {
   formRef.value.open(type, id)
+}
+
+/** 导入按钮操作 */
+const handleImport = async () => {
+  importDialogVisible.value = true
+  await resetImportForm()
+}
+
+/** 提交导入 */
+const submitImportForm = async () => {
+  if (fileList.value.length === 0) {
+    message.error('请上传文件')
+    return
+  }
+  importFormLoading.value = true
+  try {
+    const formData = new FormData()
+    formData.append('file', fileList.value[0].raw as Blob)
+    const res = await ${simpleClassName}Api.import${simpleClassName}(formData)
+    const data = res.data
+    let text = '导入成功数量：' + data.successCount + '；导入失败数量：' + data.failureCount + '；'
+    if (data.failureCount > 0) {
+      for (const rowNo in data.failureRows) {
+        text += '< 第' + rowNo + '行: ' + data.failureRows[rowNo] + ' >'
+      }
+    }
+    message.alert(text)
+    importDialogVisible.value = false
+    await getList()
+  } catch {
+  } finally {
+    importFormLoading.value = false
+    await resetImportForm()
+  }
+}
+
+/** 下载导入模板 */
+const handleImportTemplate = async () => {
+  const data = await ${simpleClassName}Api.import${simpleClassName}Template()
+  download.excel(data, '${table.classComment}导入模板.xls')
+}
+
+/** 导入文件超限 */
+const handleImportExceed = (): void => {
+  message.error('最多只能上传一个文件！')
+}
+
+/** 重置导入表单 */
+const resetImportForm = async () => {
+  fileList.value = []
+  await nextTick()
+  uploadRef.value?.clearFiles()
 }
 
 /** 删除按钮操作 */


### PR DESCRIPTION
  ## 变更背景

  为代码生成器补充通用的“Excel 导入”能力，目标是让单表、树表、主子表生成后默认具备导入
  能力，并保证前后端模板配套。
<img width="1670" height="930" alt="image" src="https://github.com/user-attachments/assets/847081c2-52e9-4a0e-8301-a143394434ae" />

  ## 本次改动

  ### 1) 后端模板增强（代码生成模板）
  - 新增导入 VO 模板：
    - `ImportExcelVO`
    - `ImportRespVO`
  - Controller 模板新增导入相关接口：
    - `GET /get-import-template`
    - `POST /import`
  - Service/ServiceImpl 模板新增导入方法：
    - `importXXXList(List<ImportExcelVO>)`
  - SQL 菜单权限模板补充 `import` 权限。
  - CodegenEngine 增加导入 VO 模板输出映射。

  ### 2) 前端 Vue3 模板增强（代码生成模板）
  - 生成的列表页新增【导入】按钮（权限：`${permissionPrefix}:import`）。
  - 新增导入弹窗（上传 xls/xlsx、下载模板、提交导入）。
  - 生成的 API 模板新增：
    - `importXXXTemplate()`（下载导入模板）
    - `importXXX(formData)`（上传导入）

  ### 3) 导入失败提示优化
  - 导入失败时返回根因短消息，避免把 MyBatis 长异常直接透传到前端。

  ## 影响范围

  - 仅影响“代码生成模板”及其生成结果。
  - 对已有历史已生成代码无自动修改；需要重新生成后才生效。
  - 适用模板：单表、树表、主子表（Vue3 + Java 后端模板链路）。

  ## 验证说明

  本地已验证：
  - 使用 JDK 17（`D:\jdk\jdk17\jdk-17.0.12`）
  - `mvn -s .mvn-settings-local.xml -pl yudao-module-infra
  -Dtest=CodegenServiceImplTest test -q` 通过
  - 代码生成下载与导入链路可用，前端可触发导入接口

  ## 备注

  导入是否成功仍取决于业务表约束与字段配置（例如数据库非空字段必须在导入数据中提供）。