### PR TITLE
 feat(infra): 代码生成器导入Excel支持其他前端版本

### DIFF
--- a/yudao-module-infra/src/main/resources/codegen/vue/api/api.js.vm
+++ b/yudao-module-infra/src/main/resources/codegen/vue/api/api.js.vm
@@ -73,6 +73,24 @@ export function export${simpleClassName}Excel(params) {
     responseType: 'blob'
   })
 }
+
+// 下载${table.classComment}导入模板
+export function import${simpleClassName}Template() {
+  return request({
+    url: '${baseURL}/get-import-template',
+    method: 'get',
+    responseType: 'blob'
+  })
+}
+
+// 导入${table.classComment}
+export function import${simpleClassName}(data) {
+  return request({
+    url: '${baseURL}/import',
+    method: 'post',
+    data
+  })
+}
 ## 特殊：主子表专属逻辑
 #foreach ($subTable in $subTables)
   #set ($index = $foreach.count - 1)

--- a/yudao-module-infra/src/main/resources/codegen/vue/views/index.vue.vm
+++ b/yudao-module-infra/src/main/resources/codegen/vue/views/index.vue.vm
@@ -50,6 +50,14 @@
                    v-hasPermi="['${permissionPrefix}:create']">新增</el-button>
       </el-col>
       <el-col :span="1.5">
+        <el-button type="info" plain icon="el-icon-upload2" size="mini" @click="handleImport"
+                   :loading="importLoading" v-hasPermi="['${permissionPrefix}:import']">导入</el-button>
+      </el-col>
+      <el-col :span="1.5">
+        <el-button type="info" plain icon="el-icon-document" size="mini" @click="handleImportTemplate"
+                   v-hasPermi="['${permissionPrefix}:import']">导入模板</el-button>
+      </el-col>
+      <el-col :span="1.5">
         <el-button type="warning" plain icon="el-icon-download" size="mini" @click="handleExport" :loading="exportLoading"
                    v-hasPermi="['${permissionPrefix}:export']">导出</el-button>
       </el-col>
@@ -78,6 +86,7 @@
     #end
       <right-toolbar :showSearch.sync="showSearch" @queryTable="getList"></right-toolbar>
     </el-row>
+    <input ref="importFileRef" type="file" style="display: none" accept=".xls,.xlsx" @change="handleImportFileChange" />
 
       ## 特殊：主子表专属逻辑
       #if ( $table.templateType == 11 && $subTables && $subTables.size() > 0 )
@@ -244,6 +253,8 @@ export default {
       loading: true,
       // 导出遮罩层
       exportLoading: false,
+      // 导入遮罩层
+      importLoading: false,
       // 显示搜索条件
       showSearch: true,
       ## 特殊：树表专属逻辑（树不需要分页接口）
@@ -321,6 +332,42 @@ export default {
     /** 添加/修改操作 */
     openForm(id) {
       this.#[[$]]#refs["formRef"].open(id);
+    },
+    /** 导入按钮操作 */
+    handleImport() {
+      this.$refs.importFileRef && this.$refs.importFileRef.click();
+    },
+    /** 导入模板下载 */
+    async handleImportTemplate() {
+      const data = await ${simpleClassName}Api.import${simpleClassName}Template();
+      this.#[[$]]#download.excel(data, '${table.classComment}导入模板.xls');
+    },
+    /** 导入文件变更 */
+    async handleImportFileChange(event) {
+      const target = event.target;
+      const file = target.files && target.files[0];
+      if (!file) {
+        return;
+      }
+      this.importLoading = true;
+      try {
+        const formData = new FormData();
+        formData.append('file', file);
+        const res = await ${simpleClassName}Api.import${simpleClassName}(formData);
+        const data = res.data || res;
+        let text = '导入成功数量：' + (data.successCount || 0) + '；导入失败数量：' + (data.failureCount || 0) + '；';
+        if (data.failureRows) {
+          Object.keys(data.failureRows).forEach((rowNo) => {
+            text += '< 第' + rowNo + '行: ' + data.failureRows[rowNo] + ' >';
+          });
+        }
+        await this.$alert(text, '${table.classComment}导入结果', { dangerouslyUseHTMLString: true });
+        await this.getList();
+      } catch {
+      } finally {
+        target.value = '';
+        this.importLoading = false;
+      }
     },
     /** 删除按钮操作 */
     async handleDelete(row) {

--- a/yudao-module-infra/src/main/resources/codegen/vue3_vben/api/api.ts.vm
+++ b/yudao-module-infra/src/main/resources/codegen/vue3_vben/api/api.ts.vm
@@ -30,3 +30,13 @@ export function delete${simpleClassName}(id: number) {
 export function export${simpleClassName}(params) {
   return defHttp.download({ url: '${baseURL}/export-excel', params }, '${table.classComment}.xls')
 }
+
+// 下载${table.classComment}导入模板
+export function import${simpleClassName}Template() {
+  return defHttp.download({ url: '${baseURL}/get-import-template' }, '${table.classComment}导入模板.xls')
+}
+
+// 导入${table.classComment}
+export function import${simpleClassName}(data: FormData) {
+  return defHttp.post({ url: '${baseURL}/import', data })
+}

--- a/yudao-module-infra/src/main/resources/codegen/vue3_vben/views/index.vue.vm
+++ b/yudao-module-infra/src/main/resources/codegen/vue3_vben/views/index.vue.vm
@@ -1,18 +1,27 @@
 <script lang="ts" setup>
 import ${simpleClassName}Modal from './${simpleClassName}Modal.vue'
 import { columns, searchFormSchema } from './${classNameVar}.data'
+import { ref } from 'vue'
 import { useI18n } from '@/hooks/web/useI18n'
 import { useMessage } from '@/hooks/web/useMessage'
 import { useModal } from '@/components/Modal'
 import { IconEnum } from '@/enums/appEnum'
 import { BasicTable, TableAction, useTable } from '@/components/Table'
-import { delete${simpleClassName}, export${simpleClassName}, get${simpleClassName}Page } from '@/api/${table.moduleName}/${table.businessName}'
+import {
+  delete${simpleClassName},
+  export${simpleClassName},
+  get${simpleClassName}Page,
+  import${simpleClassName},
+  import${simpleClassName}Template,
+} from '@/api/${table.moduleName}/${table.businessName}'
 
 defineOptions({ name: '${table.className}' })
 
 const { t } = useI18n()
 const { createConfirm, createMessage } = useMessage()
 const [registerModal, { openModal }] = useModal()
+const importFileRef = ref<HTMLInputElement>()
+const importLoading = ref(false)
 
 const [registerTable, { getForm, reload }] = useTable({
   title: '${table.classComment}列表',
@@ -49,6 +58,42 @@ async function handleExport() {
   })
 }
 
+function handleImport() {
+  importFileRef.value?.click()
+}
+
+async function handleImportTemplateDownload() {
+  await import${simpleClassName}Template()
+  createMessage.success('模板下载已开始')
+}
+
+async function handleImportFileChange(event: Event) {
+  const target = event.target as HTMLInputElement
+  const file = target.files?.[0]
+  if (!file) {
+    return
+  }
+  importLoading.value = true
+  try {
+    const formData = new FormData()
+    formData.append('file', file)
+    const response: any = await import${simpleClassName}(formData)
+    const data = response?.data ?? response
+    let text =
+      '导入成功数量：' + (data?.successCount || 0) + '；导入失败数量：' + (data?.failureCount || 0) + '；'
+    if (data?.failureRows) {
+      Object.keys(data.failureRows).forEach((rowNo) => {
+        text += '< 第' + rowNo + '行: ' + data.failureRows[rowNo] + ' >'
+      })
+    }
+    createMessage.success(text)
+    await reload()
+  } finally {
+    target.value = ''
+    importLoading.value = false
+  }
+}
+
 async function handleDelete(record: Recordable) {
   await delete${simpleClassName}(record.id)
   createMessage.success(t('common.delSuccessText'))
@@ -61,6 +106,12 @@ async function handleDelete(record: Recordable) {
       <template #toolbar>
         <a-button type="primary" v-auth="['${permissionPrefix}:create']" :preIcon="IconEnum.ADD" @click="handleCreate">
           {{ t('action.create') }}
+        </a-button>
+        <a-button v-auth="['${permissionPrefix}:import']" :loading="importLoading" @click="handleImport">
+          导入
+        </a-button>
+        <a-button v-auth="['${permissionPrefix}:import']" @click="handleImportTemplateDownload">
+          导入模板
         </a-button>
         <a-button v-auth="['${permissionPrefix}:export']" :preIcon="IconEnum.EXPORT" @click="handleExport">
           {{ t('action.export') }}
@@ -87,6 +138,7 @@ async function handleDelete(record: Recordable) {
         </template>
       </template>
     </BasicTable>
+    <input ref="importFileRef" type="file" accept=".xls,.xlsx" class="hidden" @change="handleImportFileChange" />
     <${simpleClassName}Modal @register="registerModal" @success="reload()" />
   </div>
 </template>

--- a/yudao-module-infra/src/main/resources/codegen/vue3_vben5_antd/general/api/api.ts.vm
+++ b/yudao-module-infra/src/main/resources/codegen/vue3_vben5_antd/general/api/api.ts.vm
@@ -101,6 +101,16 @@ export function export${simpleClassName}(params: any) {
   return requestClient.download('${baseURL}/export-excel', { params });
 }
 
+/** 下载${table.classComment}导入模板 */
+export function import${simpleClassName}Template() {
+  return requestClient.download('${baseURL}/get-import-template');
+}
+
+/** 导入${table.classComment} */
+export function import${simpleClassName}(data: FormData) {
+  return requestClient.post('${baseURL}/import', data);
+}
+
 ## 特殊：主子表专属逻辑
 #foreach ($subTable in $subTables)
   #set ($index = $foreach.count - 1)

--- a/yudao-module-infra/src/main/resources/codegen/vue3_vben5_antd/general/views/index.vue.vm
+++ b/yudao-module-infra/src/main/resources/codegen/vue3_vben5_antd/general/views/index.vue.vm
@@ -27,9 +27,9 @@ import { getRangePickerDefaultProps } from '#/utils/rangePickerProps';
 import { $t } from '#/locales';
 #if (${table.templateType} == 2)## 树表接口
 import { handleTree } from '@vben/utils'
-import { get${simpleClassName}List, delete${simpleClassName}, export${simpleClassName} } from '#/api/${table.moduleName}/${table.businessName}';
+import { get${simpleClassName}List, delete${simpleClassName}, export${simpleClassName}, import${simpleClassName}, import${simpleClassName}Template } from '#/api/${table.moduleName}/${table.businessName}';
 #else## 标准表接口
-import { get${simpleClassName}Page, delete${simpleClassName},#if ($deleteBatchEnable) delete${simpleClassName}List,#end export${simpleClassName} } from '#/api/${table.moduleName}/${table.businessName}';
+import { get${simpleClassName}Page, delete${simpleClassName},#if ($deleteBatchEnable) delete${simpleClassName}List,#end export${simpleClassName}, import${simpleClassName}, import${simpleClassName}Template } from '#/api/${table.moduleName}/${table.businessName}';
 #end
 
 #if ($table.templateType == 12 || $table.templateType == 11) ## 内嵌和erp情况
@@ -73,6 +73,8 @@ const queryParams = reactive({
 })
 const queryFormRef = ref() // 搜索的表单
 const exportLoading = ref(false) // 导出的加载中
+const importLoading = ref(false) // 导入的加载中
+const importFileRef = ref<HTMLInputElement>()
 
 /** 查询列表 */
 async function getList() {
@@ -190,6 +192,44 @@ try {
 }
 }
 
+/** 导入模板下载 */
+async function handleImportTemplateDownload() {
+  const data = await import${simpleClassName}Template();
+  downloadFileFromBlobPart({ fileName: '${table.classComment}导入模板.xls', source: data });
+}
+
+/** 导入按钮操作 */
+function handleImport() {
+  importFileRef.value?.click();
+}
+
+/** 导入文件变更 */
+async function handleImportFileChange(event: Event) {
+  const target = event.target as HTMLInputElement;
+  const file = target.files?.[0];
+  if (!file) {
+    return;
+  }
+  importLoading.value = true;
+  try {
+    const formData = new FormData();
+    formData.append('file', file);
+    const response: any = await import${simpleClassName}(formData);
+    const data = response?.data ?? response ?? {};
+    let text = '导入成功数量：' + (data.successCount || 0) + '；导入失败数量：' + (data.failureCount || 0) + '；';
+    if (data.failureRows) {
+      Object.keys(data.failureRows).forEach((rowNo) => {
+        text += '< 第' + rowNo + '行: ' + data.failureRows[rowNo] + ' >';
+      });
+    }
+    message.info(text);
+    await getList();
+  } finally {
+    target.value = '';
+    importLoading.value = false;
+  }
+}
+
 #if (${table.templateType} == 2)
 /** 切换树形展开/收缩状态 */
 const isExpanded = ref(true);
@@ -209,6 +249,7 @@ onMounted(() => {
 <template>
   <Page auto-content-height>
     <FormModal @success="getList" />
+    <input ref="importFileRef" type="file" accept=".xls,.xlsx" class="hidden" @change="handleImportFileChange" />
 
     <Card v-if="!hiddenSearchBar" class="mb-4">
       <!-- 搜索工作栏 -->
@@ -313,6 +354,23 @@ onMounted(() => {
               v-access:code="['${permissionPrefix}:create']"
           >
             {{ $t('ui.actionTitle.create', ['${table.classComment}']) }}
+          </Button>
+          <Button
+              class="ml-2"
+              type="primary"
+              :loading="importLoading"
+              @click="handleImport"
+              v-access:code="['${permissionPrefix}:import']"
+          >
+            导入
+          </Button>
+          <Button
+              class="ml-2"
+              type="primary"
+              @click="handleImportTemplateDownload"
+              v-access:code="['${permissionPrefix}:import']"
+          >
+            导入模板
           </Button>
           <Button
               :icon="h(Download)"

--- a/yudao-module-infra/src/main/resources/codegen/vue3_vben5_antd/schema/views/index.vue.vm
+++ b/yudao-module-infra/src/main/resources/codegen/vue3_vben5_antd/schema/views/index.vue.vm
@@ -16,6 +16,8 @@ import {
   delete${simpleClassName},
   export${simpleClassName},
   get${simpleClassName}List,
+  import${simpleClassName},
+  import${simpleClassName}Template,
 } from '#/api/${table.moduleName}/${table.businessName}';
 #else## 标准表接口
 import {
@@ -24,6 +26,8 @@ import {
   delete${simpleClassName}List,#end
   export${simpleClassName},
   get${simpleClassName}Page,
+  import${simpleClassName},
+  import${simpleClassName}Template,
 } from '#/api/${table.moduleName}/${table.businessName}';
 #end
 import { $t } from '#/locales';
@@ -50,6 +54,8 @@ const [FormModal, formModalApi] = useVbenModal({
   connectedComponent: Form,
   destroyOnClose: true,
 });
+const importLoading = ref(false);
+const importFileRef = ref<HTMLInputElement>();
 #if (${table.templateType} == 2)## 树表特有：控制表格展开收缩
 
 /** 切换树形展开/收缩状态 */
@@ -135,6 +141,44 @@ async function handleExport() {
   downloadFileFromBlobPart({ fileName: '${table.classComment}.xls', source: data });
 }
 
+/** 导入模板下载 */
+async function handleImportTemplateDownload() {
+  const data = await import${simpleClassName}Template();
+  downloadFileFromBlobPart({ fileName: '${table.classComment}导入模板.xls', source: data });
+}
+
+/** 导入按钮操作 */
+function handleImport() {
+  importFileRef.value?.click();
+}
+
+/** 导入文件变更 */
+async function handleImportFileChange(event: Event) {
+  const target = event.target as HTMLInputElement;
+  const file = target.files?.[0];
+  if (!file) {
+    return;
+  }
+  importLoading.value = true;
+  try {
+    const formData = new FormData();
+    formData.append('file', file);
+    const response: any = await import${simpleClassName}(formData);
+    const data = response?.data ?? response ?? {};
+    let text = '导入成功数量：' + (data.successCount || 0) + '；导入失败数量：' + (data.failureCount || 0) + '；';
+    if (data.failureRows) {
+      Object.keys(data.failureRows).forEach((rowNo) => {
+        text += '< 第' + rowNo + '行: ' + data.failureRows[rowNo] + ' >';
+      });
+    }
+    message.info(text);
+    handleRefresh();
+  } finally {
+    target.value = '';
+    importLoading.value = false;
+  }
+}
+
 const [Grid, gridApi] = useVbenVxeGrid({
   formOptions: {
     schema: useGridFormSchema(),
@@ -210,6 +254,7 @@ const [Grid, gridApi] = useVbenVxeGrid({
 <template>
   <Page auto-content-height>
     <FormModal @success="handleRefresh" />
+    <input ref="importFileRef" type="file" accept=".xls,.xlsx" class="hidden" @change="handleImportFileChange" />
 #if ($table.templateType == 11) ## erp情况
   <div>
 #end
@@ -247,6 +292,19 @@ const [Grid, gridApi] = useVbenVxeGrid({
               onClick: handleExpand,
             },
             #end
+            {
+              label: '导入',
+              type: 'primary',
+              auth: ['${table.moduleName}:${simpleClassName_strikeCase}:import'],
+              disabled: importLoading.value,
+              onClick: handleImport,
+            },
+            {
+              label: '导入模板',
+              type: 'primary',
+              auth: ['${table.moduleName}:${simpleClassName_strikeCase}:import'],
+              onClick: handleImportTemplateDownload,
+            },
             {
               label: $t('ui.actionTitle.export'),
               type: 'primary',

--- a/yudao-module-infra/src/main/resources/codegen/vue3_vben5_ele/general/api/api.ts.vm
+++ b/yudao-module-infra/src/main/resources/codegen/vue3_vben5_ele/general/api/api.ts.vm
@@ -101,6 +101,16 @@ export function export${simpleClassName}(params: any) {
   return requestClient.download('${baseURL}/export-excel', { params });
 }
 
+/** 下载${table.classComment}导入模板 */
+export function import${simpleClassName}Template() {
+  return requestClient.download('${baseURL}/get-import-template');
+}
+
+/** 导入${table.classComment} */
+export function import${simpleClassName}(data: FormData) {
+  return requestClient.post('${baseURL}/import', data);
+}
+
 ## 特殊：主子表专属逻辑
 #foreach ($subTable in $subTables)
   #set ($index = $foreach.count - 1)

--- a/yudao-module-infra/src/main/resources/codegen/vue3_vben5_ele/general/views/index.vue.vm
+++ b/yudao-module-infra/src/main/resources/codegen/vue3_vben5_ele/general/views/index.vue.vm
@@ -26,12 +26,11 @@ import { VxeColumn, VxeTable } from '#/adapter/vxe-table';
 import { $t } from '#/locales';
 #if (${table.templateType} == 2)## 树表接口
 import { handleTree,isEmpty } from '@vben/utils'
-import { get${simpleClassName}List, delete${simpleClassName}, export${simpleClassName} } from '#/api/${table.moduleName}/${simpleClassName_strikeCase}';
+import { get${simpleClassName}List, delete${simpleClassName}, export${simpleClassName}, import${simpleClassName}, import${simpleClassName}Template } from '#/api/${table.moduleName}/${simpleClassName_strikeCase}';
 #else## 标准表接口
 import { isEmpty } from '@vben/utils';
-import { get${simpleClassName}Page, delete${simpleClassName},#if ($deleteBatchEnable) delete${simpleClassName}List,#end export${simpleClassName} } from '#/api/${table.moduleName}/${simpleClassName_strikeCase}';
+import { get${simpleClassName}Page, delete${simpleClassName},#if ($deleteBatchEnable) delete${simpleClassName}List,#end export${simpleClassName}, import${simpleClassName}, import${simpleClassName}Template } from '#/api/${table.moduleName}/${simpleClassName_strikeCase}';
 #end
-import { downloadFileFromBlobPart } from '@vben/utils';
 
 #if ($table.templateType == 12 || $table.templateType == 11) ## 内嵌和erp情况
 /** 子表的列表 */
@@ -74,6 +73,8 @@ const queryParams = reactive({
 })
 const queryFormRef = ref() // 搜索的表单
 const exportLoading = ref(false) // 导出的加载中
+const importLoading = ref(false) // 导入的加载中
+const importFileRef = ref<HTMLInputElement>()
 
 /** 查询列表 */
 const getList = async () => {
@@ -189,6 +190,44 @@ try {
 }
 }
 
+/** 导入模板下载 */
+async function handleImportTemplateDownload() {
+  const data = await import${simpleClassName}Template();
+  downloadFileFromBlobPart({ fileName: '${table.classComment}导入模板.xls', source: data });
+}
+
+/** 导入按钮操作 */
+function handleImport() {
+  importFileRef.value?.click();
+}
+
+/** 导入文件变更 */
+async function handleImportFileChange(event: Event) {
+  const target = event.target as HTMLInputElement;
+  const file = target.files?.[0];
+  if (!file) {
+    return;
+  }
+  importLoading.value = true;
+  try {
+    const formData = new FormData();
+    formData.append('file', file);
+    const response: any = await import${simpleClassName}(formData);
+    const data = response?.data ?? response ?? {};
+    let text = '导入成功数量：' + (data.successCount || 0) + '；导入失败数量：' + (data.failureCount || 0) + '；';
+    if (data.failureRows) {
+      Object.keys(data.failureRows).forEach((rowNo) => {
+        text += '< 第' + rowNo + '行: ' + data.failureRows[rowNo] + ' >';
+      });
+    }
+    ElMessage.info(text);
+    await getList();
+  } finally {
+    target.value = '';
+    importLoading.value = false;
+  }
+}
+
 #if (${table.templateType} == 2)
 /** 切换树形展开/收缩状态 */
 const isExpanded = ref(true);
@@ -208,6 +247,7 @@ onMounted(() => {
 <template>
   <Page auto-content-height>
     <FormModal @success="getList" />
+    <input ref="importFileRef" type="file" accept=".xls,.xlsx" class="hidden" @change="handleImportFileChange" />
 
     <ContentWrap v-if="!hiddenSearchBar">
       <!-- 搜索工作栏 -->
@@ -315,6 +355,23 @@ onMounted(() => {
               v-access:code="['${permissionPrefix}:create']"
           >
             {{ $t('ui.actionTitle.create', ['${table.classComment}']) }}
+          </el-button>
+          <el-button
+              class="ml-2"
+              type="primary"
+              :loading="importLoading"
+              @click="handleImport"
+              v-access:code="['${permissionPrefix}:import']"
+          >
+            导入
+          </el-button>
+          <el-button
+              class="ml-2"
+              type="primary"
+              @click="handleImportTemplateDownload"
+              v-access:code="['${permissionPrefix}:import']"
+          >
+            导入模板
           </el-button>
           <el-button
               :icon="h(Download)"

--- a/yudao-module-infra/src/main/resources/codegen/vue3_vben5_ele/schema/api/api.ts.vm
+++ b/yudao-module-infra/src/main/resources/codegen/vue3_vben5_ele/schema/api/api.ts.vm
@@ -114,6 +114,16 @@ export function export${simpleClassName}(params: any) {
   return requestClient.download('${baseURL}/export-excel', { params });
 }
 
+/** 下载${table.classComment}导入模板 */
+export function import${simpleClassName}Template() {
+  return requestClient.download('${baseURL}/get-import-template');
+}
+
+/** 导入${table.classComment} */
+export function import${simpleClassName}(data: FormData) {
+  return requestClient.post('${baseURL}/import', data);
+}
+
 ## 特殊：主子表专属逻辑
 #foreach ($subTable in $subTables)
 #set ($index = $foreach.count - 1)

--- a/yudao-module-infra/src/main/resources/codegen/vue3_vben5_ele/schema/views/index.vue.vm
+++ b/yudao-module-infra/src/main/resources/codegen/vue3_vben5_ele/schema/views/index.vue.vm
@@ -16,6 +16,8 @@ import {
   delete${simpleClassName},
   export${simpleClassName},
   get${simpleClassName}List,
+  import${simpleClassName},
+  import${simpleClassName}Template,
 } from '#/api/${table.moduleName}/${table.businessName}';
 #else## 标准表接口
 import {
@@ -24,6 +26,8 @@ import {
   delete${simpleClassName}List,#end
   export${simpleClassName},
   get${simpleClassName}Page,
+  import${simpleClassName},
+  import${simpleClassName}Template,
 } from '#/api/${table.moduleName}/${table.businessName}';
 #end
 import { $t } from '#/locales';
@@ -50,6 +54,8 @@ const [FormModal, formModalApi] = useVbenModal({
   connectedComponent: Form,
   destroyOnClose: true,
 });
+const importLoading = ref(false);
+const importFileRef = ref<HTMLInputElement>();
 #if (${table.templateType} == 2)## 树表特有：控制表格展开收缩
 
 /** 切换树形展开/收缩状态 */
@@ -133,6 +139,44 @@ async function handleExport() {
   downloadFileFromBlobPart({ fileName: '${table.classComment}.xls', source: data });
 }
 
+/** 导入模板下载 */
+async function handleImportTemplateDownload() {
+  const data = await import${simpleClassName}Template();
+  downloadFileFromBlobPart({ fileName: '${table.classComment}导入模板.xls', source: data });
+}
+
+/** 导入按钮操作 */
+function handleImport() {
+  importFileRef.value?.click();
+}
+
+/** 导入文件变更 */
+async function handleImportFileChange(event: Event) {
+  const target = event.target as HTMLInputElement;
+  const file = target.files?.[0];
+  if (!file) {
+    return;
+  }
+  importLoading.value = true;
+  try {
+    const formData = new FormData();
+    formData.append('file', file);
+    const response: any = await import${simpleClassName}(formData);
+    const data = response?.data ?? response ?? {};
+    let text = '导入成功数量：' + (data.successCount || 0) + '；导入失败数量：' + (data.failureCount || 0) + '；';
+    if (data.failureRows) {
+      Object.keys(data.failureRows).forEach((rowNo) => {
+        text += '< 第' + rowNo + '行: ' + data.failureRows[rowNo] + ' >';
+      });
+    }
+    ElMessage.info(text);
+    handleRefresh();
+  } finally {
+    target.value = '';
+    importLoading.value = false;
+  }
+}
+
 const [Grid, gridApi] = useVbenVxeGrid({
   formOptions: {
     schema: useGridFormSchema(),
@@ -208,6 +252,7 @@ const [Grid, gridApi] = useVbenVxeGrid({
 <template>
   <Page auto-content-height>
     <FormModal @success="handleRefresh" />
+    <input ref="importFileRef" type="file" accept=".xls,.xlsx" class="hidden" @change="handleImportFileChange" />
 #if ($table.templateType == 11) ## erp情况
   <div>
 #end
@@ -245,6 +290,19 @@ const [Grid, gridApi] = useVbenVxeGrid({
               onClick: handleExpand,
             },
             #end
+            {
+              label: '导入',
+              type: 'primary',
+              auth: ['${table.moduleName}:${simpleClassName_strikeCase}:import'],
+              disabled: importLoading.value,
+              onClick: handleImport,
+            },
+            {
+              label: '导入模板',
+              type: 'primary',
+              auth: ['${table.moduleName}:${simpleClassName_strikeCase}:import'],
+              onClick: handleImportTemplateDownload,
+            },
             {
               label: $t('ui.actionTitle.export'),
               type: 'primary',


### PR DESCRIPTION
## 变更背景

  在已有后端模板和 `vue3` 标准模板导入能力基础上，本 PR 继续补齐其它前端代码模板的
  Excel 导入能力，保证代码生成器在多前端类型下能力一致。

  ## 本次改动

  ### 1) API 模板增加导入接口
  为以下模板补充：

  - `importXXXTemplate()`：下载导入模板（`GET /get-import-template`）
  - `importXXX(formData)`：上传 Excel 导入（`POST /import`）

  涉及：

  - `codegen/vue/api/api.js.vm`
  - `codegen/vue3_vben/api/api.ts.vm`
  - `codegen/vue3_vben5_antd/general/api/api.ts.vm`
  - `codegen/vue3_vben5_ele/general/api/api.ts.vm`
  - `codegen/vue3_vben5_ele/schema/api/api.ts.vm`

  说明：
  - `vue3_vben5_antd/schema/api/api.ts.vm` 复用 `vue3_vben5_ele/schema/api/api.ts.vm`，
  已间接生效。

  ### 2) 列表页模板增加导入交互
  为以下模板的列表页补充：

  - 导入按钮
  - 导入模板按钮
  - 文件选择上传（xls/xlsx）
  - 导入结果提示（成功/失败数量及失败行）
  - 导入完成后刷新列表

  涉及：

  - `codegen/vue/views/index.vue.vm`
  - `codegen/vue3_vben/views/index.vue.vm`
  - `codegen/vue3_vben5_antd/general/views/index.vue.vm`
  - `codegen/vue3_vben5_antd/schema/views/index.vue.vm`
  - `codegen/vue3_vben5_ele/general/views/index.vue.vm`
  - `codegen/vue3_vben5_ele/schema/views/index.vue.vm`

  ## 覆盖范围

  已覆盖前端模板：

  - Vue2 Element UI（`vue`）
  - Vue3 Vben2（`vue3_vben`）
  - Vue3 Vben5 Antd（`general + schema`）
  - Vue3 Vben5 Element Plus（`general + schema`）

  本 PR 未包含：

  - `vue3_admin_uniapp`