### PR TITLE
OA审批示例实体类字段类型与VO不一致问题修改，Postgres不会自动转换类型

### DIFF
--- a/yudao-module-bpm/src/main/java/cn/iocoder/yudao/module/bpm/dal/dataobject/oa/BpmOALeaveDO.java
+++ b/yudao-module-bpm/src/main/java/cn/iocoder/yudao/module/bpm/dal/dataobject/oa/BpmOALeaveDO.java
@@ -42,7 +42,7 @@ public class BpmOALeaveDO extends BaseDO {
     /**
      * 请假类型
      */
-    private String type;
+    private Integer type;
     /**
      * 原因
      */


### PR DESCRIPTION
OA审批示例实体类type字段类型与VO不一致问题修改，mysql中是tinyint类型，但Java类型是String。导致从mysql切换到PostgresSql后报错，现修改为Integer类型