### PR TITLE
增加防御性代码，该部分代码可能会引起用户未设置部门，但是角色权限分配了部门以及子部门的情况下代码中的注解导致的错误

### DIFF
--- a/yudao-module-system/src/main/java/cn/iocoder/yudao/module/system/service/permission/PermissionServiceImpl.java
+++ b/yudao-module-system/src/main/java/cn/iocoder/yudao/module/system/service/permission/PermissionServiceImpl.java
@@ -313,7 +313,11 @@ public class PermissionServiceImpl implements PermissionService {
             }
             // 情况四，DEPT_DEPT_AND_CHILD
             if (Objects.equals(role.getDataScope(), DataScopeEnum.DEPT_AND_CHILD.getScope())) {
-                CollUtil.addAll(result.getDeptIds(), deptService.getChildDeptIdListFromCache(userDeptId.get()));
+                // 如果用户部门编号为空，则跳过，否则续缓存注解会导致报错
+                if (userDeptId.get() != null) {
+                    // 添加子部门编号
+                    CollUtil.addAll(result.getDeptIds(), deptService.getChildDeptIdListFromCache(userDeptId.get()));
+                }
                 // 添加本身部门编号
                 CollUtil.addAll(result.getDeptIds(), userDeptId.get());
                 continue;


### PR DESCRIPTION
增加防御性的代码
有个实际情况，用户没有使用任何部门，但是角色设置了数据权限‘部门及子部门’，然后登录的时候getpermissioninfo的时候发生了用户未设置部门的情况，导致了传入的deptId为null导致调用的方法报错，无法登陆一直提示系统内部错误，所以增加了改代码，以防问题发生，毕竟最低限度保有自己的数据权限。