### PR TITLE
fix: escape single quotes in MyBatisUtils.findInSet to prevent SQL injection

### DIFF
--- a/yudao-framework/yudao-spring-boot-starter-mybatis/src/main/java/cn/iocoder/yudao/framework/mybatis/core/util/MyBatisUtils.java
+++ b/yudao-framework/yudao-spring-boot-starter-mybatis/src/main/java/cn/iocoder/yudao/framework/mybatis/core/util/MyBatisUtils.java
@@ -165,7 +165,23 @@ public class MyBatisUtils {
         DbType dbType = JdbcUtils.getDbType();
         return DbTypeEnum.getFindInSetTemplate(dbType)
                 .replace("#{column}", column)
-                .replace("#{value}", StrUtil.toString(value));
+                .replace("#{value}", escapeSqlValue(StrUtil.toString(value)));
+    }
+
+    /**
+     * 转义 SQL 值中的单引号，防止 SQL 注入
+     *
+     * 标准 SQL 转义方式：单引号替换为两个单引号（' → ''）
+     * 适用于 MySQL、PostgreSQL、Oracle、SQL Server 等所有主流数据库
+     *
+     * @param value 原始值
+     * @return 转义后的值
+     */
+    static String escapeSqlValue(String value) {
+        if (value == null) {
+            return null;
+        }
+        return value.replace("'", "''");
     }
 
     /**

--- a/yudao-framework/yudao-spring-boot-starter-mybatis/src/test/java/cn/iocoder/yudao/framework/mybatis/core/util/MyBatisUtilsTest.java
+++ b/yudao-framework/yudao-spring-boot-starter-mybatis/src/test/java/cn/iocoder/yudao/framework/mybatis/core/util/MyBatisUtilsTest.java
@@ -98,6 +98,28 @@ public class MyBatisUtilsTest {
         assertEquals("DESC", MyBatisUtils.getOrderDirection(null));
     }
 
+    @Test
+    public void testEscapeSqlValue() {
+        // 正常值不改变
+        assertEquals("hello", MyBatisUtils.escapeSqlValue("hello"));
+        assertEquals("test@example.com", MyBatisUtils.escapeSqlValue("test@example.com"));
+
+        // 单引号被转义
+        assertEquals("''", MyBatisUtils.escapeSqlValue("'"));
+        assertEquals("it''s", MyBatisUtils.escapeSqlValue("it's"));
+        assertEquals("a''b''c", MyBatisUtils.escapeSqlValue("a'b'c"));
+
+        // null 返回 null
+        assertEquals(null, MyBatisUtils.escapeSqlValue(null));
+
+        // 空字符串
+        assertEquals("", MyBatisUtils.escapeSqlValue(""));
+
+        // SQL 注入尝试被转义
+        assertEquals("''); DROP TABLE users; --", MyBatisUtils.escapeSqlValue("'); DROP TABLE users; --"));
+        assertEquals("admin''--", MyBatisUtils.escapeSqlValue("admin'--"));
+    }
+
     private void assertOrderItem(OrderItem orderItem, String column, boolean asc) {
         assertEquals(column, orderItem.getColumn());
         assertEquals(asc, orderItem.isAsc());


### PR DESCRIPTION
## Issue for this PR

Closes #1149

## Type of change

- [x] Bug fix

## What does this PR do?

### 问题描述

`MyBatisUtils.findInSet()` 方法（`MyBatisUtils.java:164`）使用 `String.replace()` 将 `value` 参数直接嵌入 SQL 模板，未做任何转义处理。

SQL 模板示例（MySQL）：`FIND_IN_SET('#{value}', #{column}) <> 0`

当 `value` 包含单引号时，可以破坏 SQL 语义。例如传入 `'); DROP TABLE users; --`，生成的 SQL 为：

```sql
FIND_IN_SET(''); DROP TABLE users; --', column) <> 0
```

### 影响分析

该方法被 3 个 Mapper 调用：
- `TenantMapper.selectListByWebsite()` — `website` 参数来自 HTTP 请求
- `MailLogMapper.selectPage()` — `toMail` 参数来自 HTTP 请求
- `MesQcTemplateMapper.selectPage()` — `type` 参数来自 HTTP 请求

攻击者可通过构造包含单引号的查询参数注入任意 SQL，导致数据泄露或破坏。

### 修复方案

新增 `escapeSqlValue()` 方法，对 `value` 中的单引号进行标准 SQL 转义（`'` → `''`），适用于所有支持的数据库（MySQL、PostgreSQL、Oracle、SQL Server、DM、KingbaseES、OceanBase）。

改动文件：
- `MyBatisUtils.java` — 在 `findInSet()` 中调用 `escapeSqlValue()` 转义 value
- `MyBatisUtilsTest.java` — 新增 `testEscapeSqlValue()` 测试用例

## How did you verify your code works?

1. 新增单元测试 `testEscapeSqlValue()` 覆盖以下场景：
   - 正常值不变（`hello` → `hello`）
   - 单引号转义（`it's` → `it''s`）
   - 多个单引号（`a'b'c` → `a''b''c`）
   - null 和空字符串处理
   - SQL 注入尝试被转义（`'); DROP TABLE users; --` → `''); DROP TABLE users; --`）
2. 测试通过：`mvn test -pl yudao-framework/yudao-spring-boot-starter-mybatis -Dtest=MyBatisUtilsTest`

## Screenshots / recordings

N/A