### PR TITLE
fix: prevent duplicate payment from concurrent order submission and callback

### DIFF
--- a/yudao-module-pay/src/main/java/cn/iocoder/yudao/module/pay/dal/redis/RedisKeyConstants.java
+++ b/yudao-module-pay/src/main/java/cn/iocoder/yudao/module/pay/dal/redis/RedisKeyConstants.java
@@ -26,6 +26,15 @@ public interface RedisKeyConstants {
     String PAY_WALLET_LOCK = "pay_wallet:lock:%d";
 
     /**
+     * 支付订单提交的分布式锁
+     *
+     * KEY 格式：pay_order:submit:lock:{orderId}
+     * VALUE 数据格式：HASH // RLock.class：Redisson 的 Lock 锁，使用 Hash 数据结构
+     * 过期时间：不固定
+     */
+    String PAY_ORDER_SUBMIT_LOCK = "pay_order:submit:lock:%d";
+
+    /**
      * 支付序号的缓存
      *
      * KEY 格式：pay_no:{prefix}

--- a/yudao-module-pay/src/main/java/cn/iocoder/yudao/module/pay/dal/redis/order/PayOrderLockRedisDAO.java
+++ b/yudao-module-pay/src/main/java/cn/iocoder/yudao/module/pay/dal/redis/order/PayOrderLockRedisDAO.java
@@ -1,0 +1,41 @@
+package cn.iocoder.yudao.module.pay.dal.redis.order;
+
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Repository;
+
+import javax.annotation.Resource;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+import static cn.iocoder.yudao.module.pay.dal.redis.RedisKeyConstants.PAY_ORDER_SUBMIT_LOCK;
+
+/**
+ * 支付订单的锁 Redis DAO
+ *
+ * 用于防止并发提交同一支付订单导致创建多个支付拓展单（重复支付风险）
+ *
+ * @author 芋道源码
+ */
+@Repository
+public class PayOrderLockRedisDAO {
+
+    @Resource
+    private RedissonClient redissonClient;
+
+    public <V> V lock(Long orderId, Long timeoutMillis, Callable<V> callable) throws Exception {
+        String lockKey = formatKey(orderId);
+        RLock lock = redissonClient.getLock(lockKey);
+        try {
+            lock.lock(timeoutMillis, TimeUnit.MILLISECONDS);
+            return callable.call();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private static String formatKey(Long orderId) {
+        return String.format(PAY_ORDER_SUBMIT_LOCK, orderId);
+    }
+
+}

--- a/yudao-module-pay/src/main/java/cn/iocoder/yudao/module/pay/service/order/PayOrderServiceImpl.java
+++ b/yudao-module-pay/src/main/java/cn/iocoder/yudao/module/pay/service/order/PayOrderServiceImpl.java
@@ -24,6 +24,7 @@ import cn.iocoder.yudao.module.pay.dal.dataobject.order.PayOrderExtensionDO;
 import cn.iocoder.yudao.module.pay.dal.mysql.order.PayOrderExtensionMapper;
 import cn.iocoder.yudao.module.pay.dal.mysql.order.PayOrderMapper;
 import cn.iocoder.yudao.module.pay.dal.redis.no.PayNoRedisDAO;
+import cn.iocoder.yudao.module.pay.dal.redis.order.PayOrderLockRedisDAO;
 import cn.iocoder.yudao.module.pay.enums.notify.PayNotifyTypeEnum;
 import cn.iocoder.yudao.module.pay.enums.order.PayOrderStatusEnum;
 import cn.iocoder.yudao.module.pay.framework.pay.config.PayProperties;
@@ -66,6 +67,8 @@ public class PayOrderServiceImpl implements PayOrderService {
     private PayOrderExtensionMapper orderExtensionMapper;
     @Resource
     private PayNoRedisDAO noRedisDAO;
+    @Resource
+    private PayOrderLockRedisDAO orderLockRedisDAO;
 
     @Resource
     private PayAppService appService;
@@ -140,6 +143,14 @@ public class PayOrderServiceImpl implements PayOrderService {
 
     @Override // 注意，这里不能添加事务注解，避免调用支付渠道失败时，将 PayOrderExtensionDO 回滚了
     public PayOrderSubmitRespVO submitOrder(PayOrderSubmitReqVO reqVO, String userIp) {
+        try {
+            return orderLockRedisDAO.lock(reqVO.getId(), 60 * 1000L, () -> doSubmitOrder(reqVO, userIp));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private PayOrderSubmitRespVO doSubmitOrder(PayOrderSubmitReqVO reqVO, String userIp) {
         // 1.1 获得 PayOrderDO ，并校验其是否存在
         PayOrderDO order = validateOrderCanSubmit(reqVO.getId());
         // 1.32 校验支付渠道是否有效
@@ -348,9 +359,9 @@ public class PayOrderServiceImpl implements PayOrderService {
         if (order == null) {
             throw exception(PAY_ORDER_NOT_FOUND);
         }
-        if (PayOrderStatusEnum.isSuccess(order.getStatus()) // 如果已经是成功，直接返回，不用重复更新
-                && Objects.equals(order.getExtensionId(), orderExtension.getId())) {
-            log.info("[updateOrderExtensionSuccess][order({}) 已经是已支付，无需更新]", order.getId());
+        if (PayOrderStatusEnum.isSuccess(order.getStatus())) { // 如果已经是成功，直接返回，不用重复更新（可能是并发回调或支付平台重复通知）
+            log.info("[updateOrderExtensionSuccess][order({}) 已经是已支付，无需重复更新，当前 extension({})]",
+                    order.getId(), orderExtension.getId());
             return true;
         }
         if (!PayOrderStatusEnum.WAITING.getStatus().equals(order.getStatus())) { // 校验状态，必须是待支付
@@ -366,8 +377,9 @@ public class PayOrderServiceImpl implements PayOrderService {
                         .channelFeeRate(channel.getFeeRate())
                         .channelFeePrice(MoneyUtils.calculateRatePrice(order.getPrice(), channel.getFeeRate()))
                         .build());
-        if (updateCounts == 0) { // 校验状态，必须是待支付
-            throw exception(PAY_ORDER_STATUS_IS_NOT_WAITING);
+        if (updateCounts == 0) { // 并发场景下，另一个回调已将订单更新为成功，视为重复回调
+            log.info("[updateOrderExtensionSuccess][order({}) 更新失败，可能已被其他回调更新为已支付]", order.getId());
+            return true;
         }
         log.info("[updateOrderExtensionSuccess][order({}) 更新为已支付]", order.getId());
         return false;

--- a/yudao-module-pay/src/test/java/cn/iocoder/yudao/module/pay/service/order/PayOrderServiceTest.java
+++ b/yudao-module-pay/src/test/java/cn/iocoder/yudao/module/pay/service/order/PayOrderServiceTest.java
@@ -15,6 +15,7 @@ import cn.iocoder.yudao.module.pay.dal.dataobject.order.PayOrderExtensionDO;
 import cn.iocoder.yudao.module.pay.dal.mysql.order.PayOrderExtensionMapper;
 import cn.iocoder.yudao.module.pay.dal.mysql.order.PayOrderMapper;
 import cn.iocoder.yudao.module.pay.dal.redis.no.PayNoRedisDAO;
+import cn.iocoder.yudao.module.pay.dal.redis.order.PayOrderLockRedisDAO;
 import cn.iocoder.yudao.module.pay.enums.PayChannelEnum;
 import cn.iocoder.yudao.module.pay.enums.notify.PayNotifyTypeEnum;
 import cn.iocoder.yudao.module.pay.enums.order.PayOrderStatusEnum;
@@ -54,7 +55,7 @@ import static org.mockito.Mockito.*;
  *
  * @author 芋艿
  */
-@Import({PayOrderServiceImpl.class, PayNoRedisDAO.class})
+@Import({PayOrderServiceImpl.class, PayNoRedisDAO.class, PayOrderLockRedisDAO.class})
 public class PayOrderServiceTest extends BaseDbAndRedisUnitTest {
 
     @Resource
@@ -1103,6 +1104,53 @@ public class PayOrderServiceTest extends BaseDbAndRedisUnitTest {
         order.setStatus(PayOrderStatusEnum.CLOSED.getStatus());
         assertPojoEquals(order, orderMapper.selectOne(null),
                 "updateTime", "updater");
+    }
+
+    @Test
+    public void testNotifyOrderSuccess_concurrentDuplicateCallback() {
+        // 场景：同一订单有两个 extension（微信+支付宝），两个回调同时到达
+        // 第一个回调成功更新订单为 SUCCESS，第二个回调应被优雅处理（不抛异常）
+
+        // mock 数据（PayOrderDO）- 初始状态为 WAITING
+        PayOrderDO order = randomPojo(PayOrderDO.class,
+                o -> o.setStatus(PayOrderStatusEnum.WAITING.getStatus())
+                        .setPrice(10));
+        orderMapper.insert(order);
+        // mock 数据（extension A - 微信）
+        PayOrderExtensionDO extensionA = randomPojo(PayOrderExtensionDO.class,
+                o -> o.setStatus(PayOrderStatusEnum.WAITING.getStatus())
+                        .setNo("WX_P110")
+                        .setOrderId(order.getId()));
+        orderExtensionMapper.insert(extensionA);
+        // mock 数据（extension B - 支付宝）
+        PayOrderExtensionDO extensionB = randomPojo(PayOrderExtensionDO.class,
+                o -> o.setStatus(PayOrderStatusEnum.WAITING.getStatus())
+                        .setNo("ALI_P110")
+                        .setOrderId(order.getId()));
+        orderExtensionMapper.insert(extensionB);
+
+        // 模拟第一个回调（微信）成功
+        PayChannelDO channelWx = randomPojo(PayChannelDO.class, o -> o.setId(10L).setFeeRate(10D));
+        PayOrderRespDTO notifyWx = randomPojo(PayOrderRespDTO.class,
+                o -> o.setStatus(PayOrderStatusEnum.SUCCESS.getStatus())
+                        .setOutTradeNo("WX_P110"));
+        orderService.notifyOrder(channelWx, notifyWx);
+
+        // 验证订单已更新为 SUCCESS
+        PayOrderDO updatedOrder = orderMapper.selectById(order.getId());
+        assertEquals(PayOrderStatusEnum.SUCCESS.getStatus(), updatedOrder.getStatus());
+
+        // 模拟第二个回调（支付宝）到达，此时订单已是 SUCCESS
+        PayChannelDO channelAli = randomPojo(PayChannelDO.class, o -> o.setId(20L).setFeeRate(10D));
+        PayOrderRespDTO notifyAli = randomPojo(PayOrderRespDTO.class,
+                o -> o.setStatus(PayOrderStatusEnum.SUCCESS.getStatus())
+                        .setOutTradeNo("ALI_P110"));
+        // 关键：第二个回调不应抛异常，应被优雅处理
+        orderService.notifyOrder(channelAli, notifyAli);
+
+        // 验证 extension B 也被更新为 SUCCESS
+        PayOrderExtensionDO updatedExtensionB = orderExtensionMapper.selectByNo("ALI_P110");
+        assertEquals(PayOrderStatusEnum.SUCCESS.getStatus(), updatedExtensionB.getStatus());
     }
 
 }


### PR DESCRIPTION
## Issue for this PR

Closes #1152

## Type of change

- [x] Bug fix

## What does this PR do?

### 问题描述

`PayOrderServiceImpl.submitOrder()` 方法存在并发安全问题，可能导致重复支付：

**场景一：并发提交**
两个请求同时调用 `submitOrder`（如先微信后支付宝），都能通过 `validateOrderCanSubmit` 校验（因为此时都还是 WAITING 状态），各自创建 `PayOrderExtensionDO`。两个渠道同时处理支付，如果都成功，用户被扣两次钱。

**场景二：并发回调**
两个不同渠道的支付回调同时到达 `notifyOrder`，第一个成功将订单更新为 SUCCESS，第二个读取到旧状态（WAITING），尝试更新时 `updateByIdAndStatus` 返回 0 行，抛出 `PAY_ORDER_STATUS_IS_NOT_WAITING` 异常。该异常会回滚整个 notify 事务，导致：
- 第二笔支付的 extension 状态未更新为 SUCCESS
- 后续回调重试不断失败
- 脏数据难以修复

### 修复方案

**1. 提交锁（防并发提交）**
- 新增 `PayOrderLockRedisDAO`，基于 Redisson 分布式锁
- `submitOrder` 入口处对 orderId 加锁，确保同一订单的提交请求串行执行
- 锁超时 60 秒，覆盖支付渠道调用耗时

**2. 回调幂等（防并发回调）**
- `updateOrderSuccess` 中，当 `updateByIdAndStatus` 返回 0 行时，不再抛异常
- 改为返回 `true`（表示重复回调），让调用方跳过后续通知记录创建
- 订单已是 SUCCESS 状态时，不再要求 `extensionId` 匹配才返回 true

### 改动文件

| 文件 | 改动 |
|------|------|
| `RedisKeyConstants.java` | 新增 `PAY_ORDER_SUBMIT_LOCK` 常量 |
| `PayOrderLockRedisDAO.java` | 新增分布式锁 DAO |
| `PayOrderServiceImpl.java` | submitOrder 加锁 + updateOrderSuccess 幂等处理 |
| `PayOrderServiceTest.java` | 新增并发回调测试用例 |

## How did you verify your code works?

1. 新增测试 `testNotifyOrderSuccess_concurrentDuplicateCallback`：
   - 创建同一订单的两个 extension（微信 + 支付宝），均为 WAITING 状态
   - 模拟第一个回调（微信）成功更新订单为 SUCCESS
   - 模拟第二个回调（支付宝）到达，验证不抛异常且 extension B 也被更新为 SUCCESS
2. 现有测试 `testNotifyOrderSuccess_order_paid` 验证订单已支付时的幂等行为
3. 现有测试 `testNotifyOrderSuccess_order_waiting` 验证正常单回调流程不受影响

## Screenshots / recordings

N/A