### PR TITLE
feat(bpm): 添加获取流程实例所属流程定义的当前版本和最新版本接口

### DIFF
--- a/yudao-module-bpm/yudao-module-bpm-api/src/main/java/cn/iocoder/yudao/module/bpm/enums/task/BpmProcessInstanceStatusEnum.java
+++ b/yudao-module-bpm/yudao-module-bpm-api/src/main/java/cn/iocoder/yudao/module/bpm/enums/task/BpmProcessInstanceStatusEnum.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 public enum BpmProcessInstanceStatusEnum implements ArrayValuable<Integer> {
 
     NOT_START(-1, "未开始"),
+    STARTED(0, "已启动"),
     RUNNING(1, "审批中"),
     APPROVE(2, "审批通过"),
     REJECT(3, "审批不通过"),

--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/controller/admin/definition/BpmProcessDefinitionController.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/controller/admin/definition/BpmProcessDefinitionController.java
@@ -12,12 +12,14 @@ import cn.iocoder.yudao.module.bpm.dal.dataobject.definition.BpmProcessDefinitio
 import cn.iocoder.yudao.module.bpm.service.definition.BpmCategoryService;
 import cn.iocoder.yudao.module.bpm.service.definition.BpmFormService;
 import cn.iocoder.yudao.module.bpm.service.definition.BpmProcessDefinitionService;
+import cn.iocoder.yudao.module.bpm.service.task.BpmProcessInstanceService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.Resource;
 import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.common.engine.impl.db.SuspensionState;
+import org.flowable.engine.history.HistoricProcessInstance;
 import org.flowable.engine.repository.Deployment;
 import org.flowable.engine.repository.ProcessDefinition;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -48,6 +50,8 @@ public class BpmProcessDefinitionController {
     private BpmFormService formService;
     @Resource
     private BpmCategoryService categoryService;
+    @Resource
+    private BpmProcessInstanceService processInstanceService;
 
     @GetMapping("/page")
     @Operation(summary = "获得流程定义分页")
@@ -128,6 +132,37 @@ public class BpmProcessDefinitionController {
         BpmnModel bpmnModel = processDefinitionService.getProcessDefinitionBpmnModel(processDefinition.getId());
         return success(BpmProcessDefinitionConvert.INSTANCE.buildProcessDefinition(
                 processDefinition, null, processDefinitionInfo, null, null, bpmnModel));
+    }
+
+    @GetMapping("/get-definition-version")
+    @Operation(summary = "获得流程实例所属的流程定义的版本号")
+    @Parameter(name = "id", description = "流程实例的编号", required = true)
+    public CommonResult<Integer> getProcessDefinitionVersion(@RequestParam("id") String id) {
+        HistoricProcessInstance processInstance = processInstanceService.getHistoricProcessInstance(id);
+        if (processInstance == null) {
+            return success(null);
+        }
+        ProcessDefinition processDefinition = processDefinitionService.getProcessDefinition(
+                processInstance.getProcessDefinitionId());
+        return success(processDefinition == null ? null : processDefinition.getVersion());
+    }
+
+    @GetMapping("/get-definition-latest-version")
+    @Operation(summary = "获得流程实例所属的流程定义的最新版本号")
+    @Parameter(name = "id", description = "流程实例的编号", required = true)
+    public CommonResult<Integer> getProcessDefinitionLatestVersion(@RequestParam("id") String id) {
+        HistoricProcessInstance processInstance = processInstanceService.getHistoricProcessInstance(id);
+        if (processInstance == null) {
+            return success(null);
+        }
+        ProcessDefinition processDefinition = processDefinitionService.getProcessDefinition(
+                processInstance.getProcessDefinitionId());
+        if (processDefinition == null) {
+            return success(null);
+        }
+        ProcessDefinition latestProcessDefinition = processDefinitionService.getLatestProcessDefinition(
+                processDefinition.getKey());
+        return success(latestProcessDefinition == null ? null : latestProcessDefinition.getVersion());
     }
 
 }

--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/framework/flowable/core/listener/BpmProcessInstanceEventListener.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/framework/flowable/core/listener/BpmProcessInstanceEventListener.java
@@ -7,6 +7,7 @@ import org.flowable.common.engine.api.delegate.event.FlowableEngineEntityEvent;
 import org.flowable.common.engine.api.delegate.event.FlowableEngineEventType;
 import org.flowable.engine.delegate.event.AbstractFlowableEngineEventListener;
 import org.flowable.engine.delegate.event.FlowableCancelledEvent;
+import org.flowable.engine.delegate.event.FlowableProcessStartedEvent;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
@@ -23,6 +24,7 @@ public class BpmProcessInstanceEventListener extends AbstractFlowableEngineEvent
 
     public static final Set<FlowableEngineEventType> PROCESS_INSTANCE_EVENTS = ImmutableSet.<FlowableEngineEventType>builder()
             .add(FlowableEngineEventType.PROCESS_CREATED)
+            .add(FlowableEngineEventType.PROCESS_STARTED)
             .add(FlowableEngineEventType.PROCESS_COMPLETED)
             .add(FlowableEngineEventType.PROCESS_CANCELLED)
             .build();
@@ -38,6 +40,11 @@ public class BpmProcessInstanceEventListener extends AbstractFlowableEngineEvent
     @Override
     protected void processCreated(FlowableEngineEntityEvent event) {
         processInstanceService.processProcessInstanceCreated((ProcessInstance)event.getEntity());
+    }
+
+    @Override
+    protected void processStarted(FlowableProcessStartedEvent event) {
+        processInstanceService.processProcessInstanceStarted((ProcessInstance)event.getEntity());
     }
 
     @Override

--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/service/definition/BpmProcessDefinitionService.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/service/definition/BpmProcessDefinitionService.java
@@ -178,4 +178,13 @@ public interface BpmProcessDefinitionService {
      */
     Deployment getDeployment(String id);
 
+    /**
+     * 获得流程定义标识对应的最新版本的流程定义
+     *
+     * @param key 流程定义的标识
+     * @return 流程定义
+     */
+    ProcessDefinition getLatestProcessDefinition(String key);
+
+
 }

--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/service/definition/BpmProcessDefinitionServiceImpl.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/service/definition/BpmProcessDefinitionServiceImpl.java
@@ -132,6 +132,13 @@ public class BpmProcessDefinitionServiceImpl implements BpmProcessDefinitionServ
     }
 
     @Override
+    public ProcessDefinition getLatestProcessDefinition(String key) {
+        return repositoryService.createProcessDefinitionQuery()
+                .processDefinitionTenantId(FlowableUtils.getTenantId())
+                .processDefinitionKey(key).latestVersion().singleResult();
+    }
+
+    @Override
     public String createProcessDefinition(Model model, BpmModelMetaInfoVO modelMetaInfo,
                                           byte[] bpmnBytes, String simpleJson, BpmFormDO form) {
         // 创建 Deployment 部署

--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/service/task/BpmProcessInstanceService.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/service/task/BpmProcessInstanceService.java
@@ -183,9 +183,16 @@ public interface BpmProcessInstanceService {
     void processProcessInstanceCompleted(ProcessInstance instance);
 
     /**
-     * 处理 ProcessInstance 开始事件，例如说：流程前置通知
+     * 处理 ProcessInstance 创建事件，例如说：流程前置通知
      *
      * @param instance 流程任务
      */
     void processProcessInstanceCreated(ProcessInstance instance);
+
+    /**
+     * 处理 ProcessInstance 启动事件，与processProcessInstanceCreated的区别是：启动事件触发时，初始的流程变量已经set，可以使用流程变量
+     *
+     * @param instance 流程任务
+     */
+    void processProcessInstanceStarted(ProcessInstance instance);
 }

--- a/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/service/task/BpmProcessInstanceServiceImpl.java
+++ b/yudao-module-bpm/yudao-module-bpm-biz/src/main/java/cn/iocoder/yudao/module/bpm/service/task/BpmProcessInstanceServiceImpl.java
@@ -937,4 +937,15 @@ public class BpmProcessInstanceServiceImpl implements BpmProcessInstanceService 
         });
     }
 
+    @Override
+    public void processProcessInstanceStarted(ProcessInstance instance) {
+        // 注意：需要基于 instance 设置租户编号，避免 Flowable 内部异步时，丢失租户编号
+        FlowableUtils.execute(instance.getTenantId(), () -> {
+            // 发送流程实例启动事件
+            processInstanceEventPublisher.sendProcessInstanceResultEvent(
+                    BpmProcessInstanceConvert.INSTANCE.buildProcessInstanceStatusEvent(
+                            this, instance,
+                            BpmProcessInstanceStatusEnum.STARTED.getStatus()));
+        });
+    }
 }


### PR DESCRIPTION
当流程图发生版本变动，此前提交的旧版本流程实例的流程详情界面，可能出现以下情况：
1. 操作界面是最新的界面（对应最新的流程图）
2. 实际运行的流程版本是旧版本
此时，用户执行操作可能会出现预期之外的异常。
此接口作用是用来判断当前流程实例对应的流程部署版本，以便控制操作界面在不同版本中显示不同的内容。防止出现上述错误。