### PR TITLE
Fix/web properties validation

### DIFF
--- a/yudao-framework/yudao-spring-boot-starter-web/src/main/java/cn/iocoder/yudao/framework/web/config/WebProperties.java
+++ b/yudao-framework/yudao-spring-boot-starter-web/src/main/java/cn/iocoder/yudao/framework/web/config/WebProperties.java
@@ -24,6 +24,7 @@ public class WebProperties {
     private Api adminApi = new Api("/admin-api", "**.controller.admin.**");
 
     @NotNull(message = "Admin UI 不能为空")
+    @Valid
     private Ui adminUi;
 
     @Data
@@ -54,7 +55,6 @@ public class WebProperties {
     }
 
     @Data
-    @Valid
     public static class Ui {
 
         /**

--- a/yudao-framework/yudao-spring-boot-starter-web/src/main/java/cn/iocoder/yudao/framework/web/config/WebProperties.java
+++ b/yudao-framework/yudao-spring-boot-starter-web/src/main/java/cn/iocoder/yudao/framework/web/config/WebProperties.java
@@ -17,8 +17,10 @@ import javax.validation.constraints.NotNull;
 public class WebProperties {
 
     @NotNull(message = "APP API 不能为空")
+    @Valid
     private Api appApi = new Api("/app-api", "**.controller.app.**");
     @NotNull(message = "Admin API 不能为空")
+    @Valid
     private Api adminApi = new Api("/admin-api", "**.controller.admin.**");
 
     @NotNull(message = "Admin UI 不能为空")
@@ -27,7 +29,6 @@ public class WebProperties {
     @Data
     @AllArgsConstructor
     @NoArgsConstructor
-    @Valid
     public static class Api {
 
         /**


### PR DESCRIPTION
Fix incorrect placement of @Valid in WebProperties.

@Valid was declared on the nested Api and Ui classes instead of the corresponding fields, which prevents proper cascade validation of nested configuration properties.

This change moves @Valid to appApi, adminApi, and adminUi.