### PR TITLE
fix(基础设施): 修复 MoneyUtils.calculator 整数除法把折扣分截断的问题（60.2% 变 60%）

### DIFF
--- a/yudao-framework/yudao-common/src/main/java/cn/iocoder/yudao/framework/common/util/number/MoneyUtils.java
+++ b/yudao-framework/yudao-common/src/main/java/cn/iocoder/yudao/framework/common/util/number/MoneyUtils.java
@@ -58,7 +58,8 @@ public class MoneyUtils {
         if (percent == null) {
             return price;
         }
-        return MoneyUtils.calculateRatePriceFloor(price, (double) (percent / 100));
+        // 注意：percent 单位为分（60.2% 传入 6020），必须先转为浮点数再除，整数除法会把 60.2% 截断成 60%
+        return MoneyUtils.calculateRatePriceFloor(price, percent / 100.0);
     }
 
     /**


### PR DESCRIPTION
### 问题

javadoc 约定 `percent` 单位为分（60.2% 传 6020），但实现为 `(double) (percent / 100)`，强转发生在整数除法之后，6020/100 先截断为 60 再转 double 类型，折扣金额始终偏小

### 修复

改为 `percent / 100.0`