### PR TITLE
fix(邮件): 修复代码块含 $ 或 \ 时 appendReplacement 抛 Illegal group reference 的问题

### DIFF
--- a/yudao-module-system/src/main/java/cn/iocoder/yudao/module/system/service/mail/MailTemplateServiceImpl.java
+++ b/yudao-module-system/src/main/java/cn/iocoder/yudao/module/system/service/mail/MailTemplateServiceImpl.java
@@ -166,7 +166,7 @@ public class MailTemplateServiceImpl implements MailTemplateService {
             // 提取 <pre> 标签内的内容
             String innerContent = matcher.group(1);
             // 返回 div 标签包裹的内容
-            matcher.appendReplacement(sb, "<div>" + innerContent + "</div>");
+            matcher.appendReplacement(sb, Matcher.quoteReplacement("<div>" + innerContent + "</div>"));
         }
         matcher.appendTail(sb);
         return sb.toString();
@@ -207,7 +207,8 @@ public class MailTemplateServiceImpl implements MailTemplateService {
             String codeBlock = matcher.group(1);
             // 为代码块添加样式
             String replacement = "<pre style=\"background-color: #f5f5f5; padding: 10px; border-radius: 5px; overflow-x: auto;\"><code>" + codeBlock + "</code></pre>";
-            matcher.appendReplacement(sb, replacement);
+            // 代码块内容可能包含 $ 或 \，需要 quoteReplacement，否则会抛 IllegalArgumentException: Illegal group reference
+            matcher.appendReplacement(sb, Matcher.quoteReplacement(replacement));
         }
         matcher.appendTail(sb);
         return sb.toString();

--- a/yudao-module-system/src/test/java/cn/iocoder/yudao/module/system/service/mail/MailTemplateServiceImplTest.java
+++ b/yudao-module-system/src/test/java/cn/iocoder/yudao/module/system/service/mail/MailTemplateServiceImplTest.java
@@ -398,4 +398,18 @@ public class MailTemplateServiceImplTest extends BaseDbUnitTest {
         assertFalse(formattedContent.contains("{activationLink}"));
     }
 
+    @Test
+    public void testFormatMailTemplateContent_dollarInCodeBlock() {
+        // 准备参数
+        Map<String, Object> params = new HashMap<>();
+
+        // 测试代码块中包含 $ 与 \（历史上 appendReplacement 会抛 IllegalArgumentException: Illegal group reference）
+        String content = "<pre><code>echo $HOME && ls \\root</code></pre>";
+
+        // 调用，并断言内容原样保留
+        String result = mailTemplateService.formatMailTemplateContent(content, params);
+        assertTrue(result.contains("echo $HOME && ls \\root"));
+        assertTrue(result.contains("<div><code>"));
+    }
+
 }


### PR DESCRIPTION
### 问题

`MailTemplateServiceImpl` 的 `formatHtmlCodeBlocks` / `replaceOuterPreWithDiv` 直接把拼好的替换串传给 `Matcher.appendReplacement`。当邮件代码块内容包含 `$` 或 `\`（如 `$HOME`、`${xxx}`、Windows 路径）时，`$`/`\` 被当作组引用/转义符，抛出 `IllegalArgumentException: Illegal group reference`，导致 `formatMailTemplateContent`（发信路径）直接失败。

### 修复

两处均用 `Matcher.quoteReplacement(...)` 包装替换串，内容按字面值输出。

### 测试

新增单测 `testFormatMailTemplateContent_dollarInCodeBlock`（代码块含 `$`、`\` 不抛异常且内容原样保留），`MailTemplateServiceImplTest` 22/22 全部通过（JDK8）。